### PR TITLE
DarkWake検知 + ログISO化 + タスク削除時ログ同時削除

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,6 +4,7 @@ DEV_FLAGS = -Xswiftc -DDEV
 
 # Run daemon in foreground (for development)
 daemon:
+	-@pkill -f 'local-runner$$' 2>/dev/null || true
 	cd daemon && swift build $(DEV_FLAGS)
 	daemon/.build/debug/local-runner
 

--- a/cli/src/web/App.tsx
+++ b/cli/src/web/App.tsx
@@ -33,7 +33,7 @@ export function App() {
     return ok;
   };
   const handleDelete = async (id: string, name: string) => {
-    if (!confirm(`タスク "${name}" を削除しますか？`)) return;
+    if (!confirm(`タスク "${name}" を削除しますか？\n\n実行ログもすべて削除されます。`)) return;
     await deleteTask(id);
     reloadTasks();
   };

--- a/daemon/Sources/Daemon/DisplayWakeState.swift
+++ b/daemon/Sources/Daemon/DisplayWakeState.swift
@@ -1,0 +1,53 @@
+import Foundation
+import IOKit.pwr_mgt
+import CoreGraphics
+
+/// DarkWake（ディスプレイ消灯中の短時間復帰）を検知し、タスク実行可否を判定する。
+///
+/// - ディスプレイ ON → 実行可
+/// - ディスプレイ OFF + Sleep防止 Assertion あり（Amphetamine等）→ 実行可
+/// - ディスプレイ OFF + Assertion なし → DarkWake、スキップ
+protocol DisplayWakeStateChecking: Sendable {
+    func shouldExecuteScheduledTasks() -> Bool
+}
+
+final class DisplayWakeState: DisplayWakeStateChecking, @unchecked Sendable {
+    func shouldExecuteScheduledTasks() -> Bool {
+        let displayID = CGMainDisplayID()
+        guard displayID != kCGNullDirectDisplay else {
+            // ディスプレイ状態を取得できない場合は安全側（実行する）
+            return true
+        }
+
+        if CGDisplayIsAsleep(displayID) == 0 {
+            return true
+        }
+
+        // ディスプレイ消灯中: Sleep防止 Assertion があれば実行を許可
+        return hasSleepPreventionAssertions()
+    }
+
+    private func hasSleepPreventionAssertions() -> Bool {
+        var assertionsStatus: Unmanaged<CFDictionary>?
+        let result = IOPMCopyAssertionsStatus(&assertionsStatus)
+        guard result == kIOReturnSuccess,
+              let cfDict = assertionsStatus?.takeRetainedValue() else {
+            return true
+        }
+
+        let dict = cfDict as NSDictionary
+        let relevantKeys = [
+            "PreventUserIdleSystemSleep",
+            "PreventUserIdleDisplaySleep",
+            "PreventSystemSleep",
+        ]
+
+        for key in relevantKeys {
+            if let value = dict[key] as? Int, value > 0 {
+                return true
+            }
+        }
+
+        return false
+    }
+}

--- a/daemon/Sources/Daemon/IPCServer.swift
+++ b/daemon/Sources/Daemon/IPCServer.swift
@@ -30,7 +30,7 @@ final class IPCServer: @unchecked Sendable {
         // ソケット作成
         serverFD = socket(AF_UNIX, SOCK_STREAM, 0)
         guard serverFD >= 0 else {
-            print("[IPC] ソケット作成に失敗: \(String(cString: strerror(errno)))")
+            Log.info("IPC", "ソケット作成に失敗: \(String(cString: strerror(errno)))")
             return
         }
 
@@ -51,13 +51,13 @@ final class IPCServer: @unchecked Sendable {
             }
         }
         guard bindResult == 0 else {
-            print("[IPC] バインドに失敗: \(String(cString: strerror(errno)))")
+            Log.info("IPC", "バインドに失敗: \(String(cString: strerror(errno)))")
             return
         }
 
         // リッスン
         guard Darwin.listen(serverFD, 5) == 0 else {
-            print("[IPC] リッスンに失敗: \(String(cString: strerror(errno)))")
+            Log.info("IPC", "リッスンに失敗: \(String(cString: strerror(errno)))")
             return
         }
 
@@ -68,7 +68,7 @@ final class IPCServer: @unchecked Sendable {
 
         // 接続受付を開始
         acceptConnections()
-        print("[IPC] 待ち受け開始: \(socketPath)")
+        Log.info("IPC", "待ち受け開始: \(socketPath)")
     }
 
     // MARK: - 接続管理
@@ -82,7 +82,7 @@ final class IPCServer: @unchecked Sendable {
                 self.lock.unlock()
 
                 guard currentServerFD >= 0 else {
-                    print("[IPC] サーバーソケットが閉じられました。接続受付を終了します")
+                    Log.info("IPC", "サーバーソケットが閉じられました。接続受付を終了します")
                     return
                 }
 

--- a/daemon/Sources/Daemon/Log.swift
+++ b/daemon/Sources/Daemon/Log.swift
@@ -1,0 +1,27 @@
+import Foundation
+
+/// システムタイムゾーンの ISO 8601 タイムスタンプ付きログ出力。
+enum Log {
+    private static let formatter: DateFormatter = {
+        let f = DateFormatter()
+        f.dateFormat = "yyyy-MM-dd'T'HH:mm:ssxxx"
+        return f
+    }()
+
+    static func info(_ tag: String, _ message: String) {
+        print("[\(formatter.string(from: Date()))] [\(tag)] \(message)")
+    }
+
+    /// Date を ISO 8601 形式 (例: 2026-03-30T17:09:03+09:00) で返す。
+    static func formatDate(_ date: Date) -> String {
+        formatter.string(from: date)
+    }
+
+    /// TimeInterval を読みやすいテキストに変換する。
+    static func formatDuration(_ interval: TimeInterval) -> String {
+        let total = Int(interval)
+        if total < 60 { return "\(total)秒" }
+        if total < 3600 { return "\(total / 60)分\(total % 60)秒" }
+        return "\(total / 3600)時間\((total % 3600) / 60)分"
+    }
+}

--- a/daemon/Sources/Daemon/LogStore.swift
+++ b/daemon/Sources/Daemon/LogStore.swift
@@ -43,6 +43,17 @@ final class LogStore: @unchecked Sendable {
         }
     }
 
+    /// 指定タスクの実行ログを全削除する。
+    func deleteHistory(taskId: String) {
+        lock.lock()
+        defer { lock.unlock() }
+
+        ensureLoaded()
+        cache.removeValue(forKey: taskId)
+        let url = directory.appendingPathComponent("\(taskId).json")
+        try? FileManager.default.removeItem(at: url)
+    }
+
     // MARK: - 読み取り
 
     /// 指定タスクの実行履歴を取得する。

--- a/daemon/Sources/Daemon/SlackNotifier.swift
+++ b/daemon/Sources/Daemon/SlackNotifier.swift
@@ -21,7 +21,7 @@ final class SlackNotifier: @unchecked Sendable {
             ":x: *タスク実行失敗: \(escapeSlack(task.name))*",
             "• コマンド: `\(escapeSlack(task.command))`",
             "• 終了コード: \(record.exitCode ?? -1)",
-            "• 時刻: \(formatDate(record.startedAt))",
+            "• 時刻: \(Log.formatDate(record.startedAt))",
             "• 実行時間: \(record.durationText)",
         ].joined(separator: "\n")
 
@@ -48,16 +48,11 @@ final class SlackNotifier: @unchecked Sendable {
 
         URLSession.shared.dataTask(with: request) { _, response, error in
             if let error {
-                print("[Slack] 送信失敗: \(error.localizedDescription)")
+                Log.info("Slack", "送信失敗: \(error.localizedDescription)")
             } else if let http = response as? HTTPURLResponse, http.statusCode != 200 {
-                print("[Slack] 予期しないステータス: \(http.statusCode)")
+                Log.info("Slack", "予期しないステータス: \(http.statusCode)")
             }
         }.resume()
     }
 
-    private func formatDate(_ date: Date) -> String {
-        let fmt = DateFormatter()
-        fmt.dateFormat = "yyyy-MM-dd HH:mm:ss"
-        return fmt.string(from: date)
-    }
 }

--- a/daemon/Sources/Daemon/TaskExecutor.swift
+++ b/daemon/Sources/Daemon/TaskExecutor.swift
@@ -37,7 +37,7 @@ final class TaskExecutor: @unchecked Sendable {
         lock.withLock { runningProcesses[task.id] = process }
 
         defer {
-            lock.withLock { runningProcesses.removeValue(forKey: task.id) }
+            lock.withLock { _ = runningProcesses.removeValue(forKey: task.id) }
         }
 
         do {

--- a/daemon/Sources/Daemon/TaskScheduler.swift
+++ b/daemon/Sources/Daemon/TaskScheduler.swift
@@ -8,6 +8,7 @@ final class TaskScheduler: @unchecked Sendable {
     private let logStore: LogStore
     private let executor = TaskExecutor()
     private let slackNotifier = SlackNotifier()
+    var displayWakeState: DisplayWakeStateChecking = DisplayWakeState()
 
     private var tasks: [TaskDefinition] = []
     private var nextFireDates: [String: Date] = [:]
@@ -16,6 +17,7 @@ final class TaskScheduler: @unchecked Sendable {
     private var fileWatchTimer: Timer?
     private var lastDirModDate: Date = .distantPast
     private let lock = NSLock()
+    private var isDarkWakePaused = false
 
     /// IPC通知用コールバック
     var onNotification: ((IPCNotification) -> Void)?
@@ -35,7 +37,7 @@ final class TaskScheduler: @unchecked Sendable {
         let settings = loadSettings()
         slackNotifier.webhookURL = settings.slackWebhookURL
         let count = lock.withLock { tasks.count }
-        print("[Scheduler] \(count) 件のタスクで起動しました")
+        Log.info("Scheduler", "\(count) 件のタスクで起動しました")
     }
 
     func stop() {
@@ -53,7 +55,7 @@ final class TaskScheduler: @unchecked Sendable {
             tasks = loaded
             recalculateFireDatesLocked()
         }
-        print("[Scheduler] 再読み込み: \(loaded.count) 件のタスク")
+        Log.info("Scheduler", "再読み込み: \(loaded.count) 件のタスク")
     }
 
     func allTaskStatuses() -> [TaskStatus] {
@@ -72,7 +74,7 @@ final class TaskScheduler: @unchecked Sendable {
     func runTaskNow(_ taskId: String) {
         let task = lock.withLock { tasks.first { $0.id == taskId } }
         guard let task else {
-            print("[Scheduler] タスクが見つかりません: \(taskId)")
+            Log.info("Scheduler", "タスクが見つかりません: \(taskId)")
             return
         }
         executeTask(task)
@@ -103,7 +105,7 @@ final class TaskScheduler: @unchecked Sendable {
         do {
             try taskStore.save(task)
         } catch {
-            print("[Scheduler] タスク \(taskId) の切り替え保存に失敗: \(error)")
+            Log.info("Scheduler", "タスク \(taskId) の切り替え保存に失敗: \(error)")
         }
         onNotification?(.tasksChanged)
     }
@@ -116,6 +118,7 @@ final class TaskScheduler: @unchecked Sendable {
 
     func deleteTask(_ taskId: String) throws {
         try taskStore.delete(taskId)
+        logStore.deleteHistory(taskId: taskId)
         reloadTasks()
         onNotification?(.tasksChanged)
     }
@@ -124,11 +127,11 @@ final class TaskScheduler: @unchecked Sendable {
 
     func handleWake(lastSleepDate: Date) {
         let tasksSnapshot = lock.withLock { tasks }
-        print("[Scheduler] スリープ復帰を検知。\(lastSleepDate) 以降の未実行タスクを確認中...")
+        Log.info("Scheduler", "スリープ復帰を検知。\(Log.formatDate(lastSleepDate)) 以降の未実行タスクを確認中...")
         for task in tasksSnapshot where task.enabled && task.catchUp {
             if let nextFire = task.schedule.nextFireDate(after: lastSleepDate),
                nextFire < Date() {
-                print("[Scheduler] キャッチアップ: \(task.name)")
+                Log.info("Scheduler", "キャッチアップ実行: \(task.name)")
                 executeTask(task)
             }
         }
@@ -168,6 +171,18 @@ final class TaskScheduler: @unchecked Sendable {
     }
 
     private func checkSchedule() {
+        guard displayWakeState.shouldExecuteScheduledTasks() else {
+            if !isDarkWakePaused {
+                isDarkWakePaused = true
+                Log.info("Scheduler", "DarkWake検知: スケジュール実行を一時停止します")
+            }
+            return
+        }
+        if isDarkWakePaused {
+            isDarkWakePaused = false
+            Log.info("Scheduler", "ディスプレイ復帰: スケジュール実行を再開します")
+        }
+
         let (tasksSnapshot, fireDates) = lock.withLock { (tasks, nextFireDates) }
         let now = Date()
 
@@ -193,7 +208,7 @@ final class TaskScheduler: @unchecked Sendable {
     }
 
     private func executeTask(_ task: TaskDefinition) {
-        print("[Scheduler] 実行開始: \(task.name)")
+        Log.info("Scheduler", "実行開始: \(task.name)")
         onNotification?(.taskStarted(task.id))
 
         // running 状態の仮レコードを保存（UI に実行中表示用）
@@ -226,7 +241,8 @@ final class TaskScheduler: @unchecked Sendable {
                 self.slackNotifier.notifyFailure(task: task, record: finalRecord)
             }
 
-            print("[Scheduler] 完了: \(task.name) → \(finalRecord.status.rawValue)")
+            let duration = finalRecord.durationText
+            Log.info("Scheduler", "完了: \(task.name) → \(finalRecord.status.rawValue) (\(duration))")
         }
     }
 }

--- a/daemon/Sources/Daemon/WakeDetector.swift
+++ b/daemon/Sources/Daemon/WakeDetector.swift
@@ -21,7 +21,7 @@ final class WakeDetector: @unchecked Sendable {
         // 永続化されたスリープ状態を復元
         sleepStartedAt = loadSleepState()
         if let restored = sleepStartedAt {
-            print("[WakeDetector] 前回のスリープ状態を復元: \(restored)")
+            Log.info("Wake", "前回のスリープ状態を復元 (スリープ開始: \(Log.formatDate(restored)))")
         }
 
         // スリープ/復帰イベントの監視
@@ -30,13 +30,14 @@ final class WakeDetector: @unchecked Sendable {
             let now = Date()
             self?.sleepStartedAt = now
             self?.saveSleepState(now)
-            print("[WakeDetector] システムがスリープに入ります")
+            Log.info("Wake", "システムがスリープに入ります")
         }
         nc.addObserver(forName: NSWorkspace.didWakeNotification, object: nil, queue: .main) { [weak self] _ in
             guard let self, let sleepDate = self.sleepStartedAt else { return }
             self.sleepStartedAt = nil
             self.clearSleepState()
-            print("[WakeDetector] システムが復帰しました (\(sleepDate) からスリープ)")
+            let duration = Log.formatDuration(Date().timeIntervalSince(sleepDate))
+            Log.info("Wake", "システムが復帰しました (スリープ: \(Log.formatDate(sleepDate)) 〜 現在, \(duration))")
             self.onWake(sleepDate)
         }
 
@@ -72,7 +73,7 @@ final class WakeDetector: @unchecked Sendable {
 
         // Heartbeat 間隔の3倍以上のギャップがあれば、デーモンが停止していたと判断
         if gap > Self.heartbeatInterval * 3 {
-            print("[WakeDetector] 起動時ギャップを検出: 最終 heartbeat \(lastHeartbeat) (約\(Int(gap))秒前)")
+            Log.info("Wake", "起動時ギャップを検出: 最終 heartbeat \(Log.formatDate(lastHeartbeat)) (\(Log.formatDuration(gap))前)")
             return lastHeartbeat
         }
 

--- a/daemon/Sources/Daemon/main.swift
+++ b/daemon/Sources/Daemon/main.swift
@@ -21,13 +21,13 @@ let wakeDetector = WakeDetector { lastAwake in
 
 // 起動時ギャップ検出（デーモン再起動・長時間停止への対応）
 if let gapStart = wakeDetector.detectStartupGap() {
-    print("[local-runner] 起動時ギャップを検出。キャッチアップを実行します")
+    Log.info("main", "起動時ギャップを検出 (最終稼働: \(Log.formatDate(gapStart)))。キャッチアップを実行します")
     scheduler.handleWake(lastSleepDate: gapStart)
 }
 
 wakeDetector.start()
 
-print("[local-runner] 起動しました (PID: \(ProcessInfo.processInfo.processIdentifier))")
+Log.info("main", "起動しました (PID: \(ProcessInfo.processInfo.processIdentifier))")
 
 // プロセスを維持（RunLoop で Timer を駆動する）
 RunLoop.main.run()

--- a/daemon/Tests/CoreTests/LogFormatTests.swift
+++ b/daemon/Tests/CoreTests/LogFormatTests.swift
@@ -1,0 +1,51 @@
+import Testing
+import Foundation
+
+/// Log.formatDuration (Daemon ターゲット) のロジック検証。
+/// Daemon は executableTarget のため CoreTests から直接 import できない。
+/// ロジックをミラーしてアルゴリズムの正しさを担保する。
+/// Log.formatDuration を変更した場合はこのテストも同期すること。
+private func formatDuration(_ interval: TimeInterval) -> String {
+    let total = Int(interval)
+    if total < 60 { return "\(total)秒" }
+    if total < 3600 { return "\(total / 60)分\(total % 60)秒" }
+    return "\(total / 3600)時間\((total % 3600) / 60)分"
+}
+
+@Suite("Log.formatDuration logic")
+struct FormatDurationTests {
+    @Test("Under 60 seconds shows seconds")
+    func seconds() {
+        #expect(formatDuration(0) == "0秒")
+        #expect(formatDuration(1) == "1秒")
+        #expect(formatDuration(59) == "59秒")
+    }
+
+    @Test("Boundary at 60 seconds switches to minutes")
+    func minutesBoundary() {
+        #expect(formatDuration(60) == "1分0秒")
+    }
+
+    @Test("Minutes and seconds")
+    func minutesAndSeconds() {
+        #expect(formatDuration(90) == "1分30秒")
+        #expect(formatDuration(3599) == "59分59秒")
+    }
+
+    @Test("Boundary at 3600 seconds switches to hours")
+    func hoursBoundary() {
+        #expect(formatDuration(3600) == "1時間0分")
+    }
+
+    @Test("Hours and minutes")
+    func hoursAndMinutes() {
+        #expect(formatDuration(3661) == "1時間1分")
+        #expect(formatDuration(7200) == "2時間0分")
+    }
+
+    @Test("Fractional seconds are truncated to integer")
+    func fractional() {
+        #expect(formatDuration(59.9) == "59秒")
+        #expect(formatDuration(0.5) == "0秒")
+    }
+}


### PR DESCRIPTION
## Summary
- macOS DarkWake（蓋閉じ中の短時間メンテナンス復帰）を検知し、スケジュールタスクの実行をスキップする機能を追加
- Amphetamine等のSleep防止アプリが有効な場合は意図的な起動と判断し実行を継続
- 全ログ出力をISO 8601タイムスタンプ（システムタイムゾーン）付きに統一
- タスク削除時に実行ログファイルも同時削除するように変更
- `make daemon` 実行時に既存プロセスを自動killして多重起動を防止

## Diff

### DarkWake検知
```
Before: 蓋を閉じてもDarkWakeのたびにタスクが~15分間隔で実行される
After:  DarkWake中はスケジュール実行をスキップ（手動実行・復帰キャッチアップは影響なし）
        ただしSleep防止Assertion検出時は実行を継続
```

```
DisplayWakeState.shouldExecuteScheduledTasks()
  │
  ├─ Display ON ──────────────────→ 実行する
  │
  └─ Display OFF
       ├─ Sleep防止Assertion あり → 実行する (Amphetamine等)
       └─ Assertion なし ────────→ スキップ (DarkWake)
```

### ログ出力
```
Before: [Scheduler] 実行開始: test task
After:  [2026-03-30T17:09:03+09:00] [Scheduler] 実行開始: test task
```

### タスク削除
```
Before: タスク定義のみ削除、ログファイルは孤立して残る
After:  タスク定義 + 実行ログを同時削除、確認ダイアログにその旨を表示
```

### Makefile
```
Before: make daemon で古いプロセスが残り多重起動
After:  起動前に pkill で既存プロセスを自動停止
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)