### PR TITLE
IPC再接続の堅牢化 + daemon未接続時の専用UI

### DIFF
--- a/cli/src/ipc.test.ts
+++ b/cli/src/ipc.test.ts
@@ -1,0 +1,128 @@
+import { test, expect, afterEach } from "bun:test";
+import { IPCClient } from "./ipc.ts";
+import { unlinkSync } from "fs";
+import { join } from "path";
+import { tmpdir } from "os";
+
+function testSocketPath() {
+  return join(tmpdir(), `lr-test-${Date.now()}-${Math.random().toString(36).slice(2)}.sock`);
+}
+
+// Wire format helper: 4-byte big-endian length prefix + JSON
+function encodeResponse(obj: unknown): Buffer {
+  const json = Buffer.from(JSON.stringify(obj), "utf-8");
+  const header = Buffer.alloc(4);
+  header.writeUInt32BE(json.length, 0);
+  return Buffer.concat([header, json]);
+}
+
+const cleanupPaths: string[] = [];
+const cleanupServers: { stop(): void }[] = [];
+
+afterEach(() => {
+  for (const s of cleanupServers) s.stop();
+  cleanupServers.length = 0;
+  for (const p of cleanupPaths) {
+    try { unlinkSync(p); } catch {}
+  }
+  cleanupPaths.length = 0;
+});
+
+test("send() rejects with timeout when daemon does not respond", async () => {
+  const sockPath = testSocketPath();
+  cleanupPaths.push(sockPath);
+
+  // Accept connections but never respond
+  const server = Bun.listen({
+    unix: sockPath,
+    socket: {
+      data() {},
+      open() {},
+      close() {},
+    },
+  });
+  cleanupServers.push(server);
+
+  const client = new IPCClient();
+  await client.connect(sockPath);
+
+  try {
+    await expect(
+      client.send({ action: "list_tasks" }, 100),
+    ).rejects.toThrow("タイムアウト");
+  } finally {
+    client.close();
+  }
+});
+
+test("send() resolves when daemon responds within timeout", async () => {
+  const sockPath = testSocketPath();
+  cleanupPaths.push(sockPath);
+
+  const server = Bun.listen({
+    unix: sockPath,
+    socket: {
+      data(socket) {
+        socket.write(encodeResponse({ success: true, tasks: [] }));
+      },
+      open() {},
+      close() {},
+    },
+  });
+  cleanupServers.push(server);
+
+  const client = new IPCClient();
+  await client.connect(sockPath);
+
+  try {
+    const res = await client.send({ action: "list_tasks" }, 1000);
+    expect(res.success).toBe(true);
+  } finally {
+    client.close();
+  }
+});
+
+test("send() cleans up pending entry on timeout", async () => {
+  const sockPath = testSocketPath();
+  cleanupPaths.push(sockPath);
+
+  const server = Bun.listen({
+    unix: sockPath,
+    socket: {
+      data() {},
+      open() {},
+      close() {},
+    },
+  });
+  cleanupServers.push(server);
+
+  const client = new IPCClient();
+  await client.connect(sockPath);
+
+  try {
+    // Send and let it timeout
+    await client.send({ action: "list_tasks" }, 50).catch(() => {});
+    // A second send should still work (pending queue not corrupted)
+    await expect(
+      client.send({ action: "list_tasks" }, 50),
+    ).rejects.toThrow("タイムアウト");
+  } finally {
+    client.close();
+  }
+});
+
+test("send() rejects immediately when not connected", async () => {
+  const client = new IPCClient();
+
+  await expect(
+    client.send({ action: "list_tasks" }),
+  ).rejects.toThrow("接続されていません");
+});
+
+test("connect() rejects when socket path does not exist", async () => {
+  const client = new IPCClient();
+
+  await expect(
+    client.connect("/tmp/nonexistent-lr-test.sock"),
+  ).rejects.toThrow();
+});

--- a/cli/src/ipc.ts
+++ b/cli/src/ipc.ts
@@ -173,7 +173,7 @@ export class IPCClient {
     }
   }
 
-  async send(request: IPCRequest): Promise<IPCResponse> {
+  async send(request: IPCRequest, timeout = 5000): Promise<IPCResponse> {
     if (!this.socket) {
       throw new Error("デーモンに接続されていません。デーモンは起動していますか？");
     }
@@ -181,7 +181,23 @@ export class IPCClient {
     this.socket.write(encoded);
 
     return new Promise((resolve, reject) => {
-      this.pending.push({ resolve, reject });
+      const timer = setTimeout(() => {
+        const idx = this.pending.indexOf(entry);
+        if (idx !== -1) this.pending.splice(idx, 1);
+        reject(new Error("IPC リクエストがタイムアウトしました"));
+      }, timeout);
+
+      const entry = {
+        resolve: (value: IPCResponse) => {
+          clearTimeout(timer);
+          resolve(value);
+        },
+        reject: (reason: unknown) => {
+          clearTimeout(timer);
+          reject(reason);
+        },
+      };
+      this.pending.push(entry);
     });
   }
 

--- a/cli/src/serve.ts
+++ b/cli/src/serve.ts
@@ -1,4 +1,4 @@
-import { IPCClient, getSocketPath, type IPCNotification } from "./ipc.ts";
+import { IPCClient, getSocketPath, type IPCNotification, type IPCRequest, type IPCResponse } from "./ipc.ts";
 import { existsSync, statSync } from "fs";
 import { homedir } from "os";
 import { resolve } from "path";
@@ -17,15 +17,42 @@ type ServerWebSocket<T> = {
 
 async function ensureIPC(): Promise<IPCClient> {
   if (ipcClient?.connected) return ipcClient;
-  ipcClient = new IPCClient();
-  await ipcClient.connect();
-  ipcClient.subscribe((notification: IPCNotification) => {
+  const wasReconnect = ipcClient !== null;
+  const client = new IPCClient();
+  try {
+    await client.connect();
+  } catch (err) {
+    ipcClient = null;
+    throw err;
+  }
+  ipcClient = client;
+  client.subscribe((notification: IPCNotification) => {
     const msg = JSON.stringify({ type: "notification", ...notification });
     for (const ws of wsClients) {
       ws.send(msg);
     }
   });
-  return ipcClient;
+  // 再接続時、既存のWSクライアントにリフレッシュを通知
+  if (wasReconnect && wsClients.size > 0) {
+    const refreshMsg = JSON.stringify({ type: "notification", event: "reconnected" });
+    for (const ws of wsClients) {
+      ws.send(refreshMsg);
+    }
+  }
+  return client;
+}
+
+async function sendToIPC(request: IPCRequest): Promise<IPCResponse> {
+  try {
+    const client = await ensureIPC();
+    return await client.send(request);
+  } catch {
+    // 接続が切れていた可能性 — リセットして1回リトライ
+    ipcClient?.close();
+    ipcClient = null;
+    const client = await ensureIPC();
+    return await client.send(request);
+  }
 }
 
 // --- API handlers ---
@@ -53,17 +80,15 @@ async function handleAPI(req: Request): Promise<Response> {
   }
 
   try {
-    const client = await ensureIPC();
-
     if (path === "/api/tasks" && req.method === "GET") {
-      const res = await client.send({ action: "list_tasks" });
+      const res = await sendToIPC({ action: "list_tasks" });
       return Response.json(res);
     }
 
     if (path === "/api/history" && req.method === "GET") {
       const taskId = url.searchParams.get("taskId") ?? undefined;
       const limit = parseInt(url.searchParams.get("limit") ?? "50", 10);
-      const res = await client.send({ action: "get_history", taskId, limit });
+      const res = await sendToIPC({ action: "get_history", taskId, limit });
       return Response.json(res);
     }
 
@@ -71,39 +96,38 @@ async function handleAPI(req: Request): Promise<Response> {
       const taskId = path.split("/")[3];
       const action = path.split("/")[4]; // run, stop, toggle
       if (action === "run") {
-        const res = await client.send({ action: "run_task", taskId });
+        const res = await sendToIPC({ action: "run_task", taskId });
         return Response.json(res);
       }
       if (action === "stop") {
-        const res = await client.send({ action: "stop_task", taskId });
+        const res = await sendToIPC({ action: "stop_task", taskId });
         return Response.json(res);
       }
       if (action === "toggle") {
-        const res = await client.send({ action: "toggle_task", taskId });
+        const res = await sendToIPC({ action: "toggle_task", taskId });
         return Response.json(res);
       }
     }
 
     if (path === "/api/tasks" && req.method === "POST") {
       const body = await req.json();
-      const res = await client.send({ action: "save_task", task: body });
+      const res = await sendToIPC({ action: "save_task", task: body });
       return Response.json(res);
     }
 
     if (path.startsWith("/api/tasks/") && req.method === "DELETE") {
       const taskId = path.split("/")[3];
-      const res = await client.send({ action: "delete_task", taskId });
+      const res = await sendToIPC({ action: "delete_task", taskId });
       return Response.json(res);
     }
 
     if (path === "/api/settings" && req.method === "GET") {
-      const res = await client.send({ action: "get_settings" });
+      const res = await sendToIPC({ action: "get_settings" });
       return Response.json(res);
     }
 
     return Response.json({ error: "見つかりません" }, { status: 404 });
   } catch (err) {
-    ipcClient = null;
     return Response.json(
       { error: `デーモンへの接続に失敗: ${err}` },
       { status: 502 }

--- a/cli/src/web/App.tsx
+++ b/cli/src/web/App.tsx
@@ -7,10 +7,38 @@ import type { TaskDefinition } from "./types.ts";
 
 type Tab = "tasks" | "timeline";
 
+function DisconnectedView({ onRetry, retrying }: { onRetry: () => void; retrying: boolean }) {
+  return (
+    <div className="onboarding">
+      <div className="onboarding-card">
+        <div className="onboarding-icon">
+          <svg viewBox="0 0 48 48" fill="none">
+            <rect x="4" y="4" width="40" height="40" rx="12" fill="var(--red-dim)" stroke="var(--red)" strokeWidth="1.5" />
+            <path d="M16 16L32 32M32 16L16 32" stroke="var(--red)" strokeWidth="2.5" strokeLinecap="round" />
+          </svg>
+        </div>
+        <h2 className="onboarding-title">デーモンに接続できません</h2>
+        <p className="onboarding-desc">
+          LocalRunner デーモンが起動していないか、<br />
+          接続に問題が発生しています。
+        </p>
+        <button
+          className="btn btn-primary onboarding-cta"
+          onClick={onRetry}
+          disabled={retrying}
+        >
+          {retrying ? "接続中..." : "再接続"}
+        </button>
+      </div>
+    </div>
+  );
+}
+
 export function App() {
   const [tab, setTab] = useState<Tab>("tasks");
-  const { tasks, loading: tasksLoading, reload: reloadTasks } = useTasks();
+  const { tasks, loading: tasksLoading, error: tasksError, reload: reloadTasks } = useTasks();
   const { history, reload: reloadTimeline } = useTimeline();
+  const [retrying, setRetrying] = useState(false);
 
   const handleMessage = useCallback(() => {
     reloadTasks();
@@ -18,6 +46,14 @@ export function App() {
   }, [reloadTasks, reloadTimeline]);
 
   const connected = useWebSocket(handleMessage);
+
+  const daemonConnected = !tasksError;
+
+  const handleRetry = async () => {
+    setRetrying(true);
+    await reloadTasks(false);
+    setRetrying(false);
+  };
 
   const handleRun = async (id: string) => {
     await runTask(id);
@@ -49,38 +85,44 @@ export function App() {
           </div>
           <h1>LocalRunner</h1>
         </div>
-        <span className={`conn-badge ${connected ? "connected" : "disconnected"}`}>
-          {connected ? "接続中" : "切断"}
+        <span className={`conn-badge ${connected && daemonConnected ? "connected" : "disconnected"}`}>
+          {connected && daemonConnected ? "接続中" : "切断"}
         </span>
       </header>
 
       <main>
-        <div className="tabs">
-          <button
-            className={`tab ${tab === "tasks" ? "active" : ""}`}
-            onClick={() => setTab("tasks")}
-          >
-            タスク
-          </button>
-          <button
-            className={`tab ${tab === "timeline" ? "active" : ""}`}
-            onClick={() => setTab("timeline")}
-          >
-            実行ログ
-          </button>
-        </div>
+        {!tasksLoading && !daemonConnected ? (
+          <DisconnectedView onRetry={handleRetry} retrying={retrying} />
+        ) : (
+          <>
+            <div className="tabs">
+              <button
+                className={`tab ${tab === "tasks" ? "active" : ""}`}
+                onClick={() => setTab("tasks")}
+              >
+                タスク
+              </button>
+              <button
+                className={`tab ${tab === "timeline" ? "active" : ""}`}
+                onClick={() => setTab("timeline")}
+              >
+                実行ログ
+              </button>
+            </div>
 
-        {tab === "tasks" && (
-          <TasksView
-            tasks={tasks}
-            loading={tasksLoading}
-            onRun={handleRun}
-            onStop={handleStop}
-            onSave={handleSave}
-            onDelete={handleDelete}
-          />
+            {tab === "tasks" && (
+              <TasksView
+                tasks={tasks}
+                loading={tasksLoading}
+                onRun={handleRun}
+                onStop={handleStop}
+                onSave={handleSave}
+                onDelete={handleDelete}
+              />
+            )}
+            {tab === "timeline" && <TimelineView history={history} />}
+          </>
         )}
-        {tab === "timeline" && <TimelineView history={history} />}
       </main>
 
       <ToastContainer />

--- a/cli/src/web/hooks.ts
+++ b/cli/src/web/hooks.ts
@@ -5,14 +5,22 @@ import { formatCountdown } from "./format.ts";
 export function useTasks() {
   const [tasks, setTasks] = useState<TaskStatus[]>([]);
   const [loading, setLoading] = useState(true);
+  const [error, setError] = useState(false);
 
-  const load = useCallback(async () => {
+  const load = useCallback(async (retry = true) => {
     try {
       const res = await fetch("/api/tasks");
+      if (!res.ok) throw new Error(`HTTP ${res.status}`);
       const data = await res.json();
       setTasks(data.tasks ?? []);
+      setError(false);
     } catch {
-      // ignore
+      setError(true);
+      // エラー時は既存のタスクを維持（初回ロードなら空のまま）
+      // 1回だけリトライ
+      if (retry) {
+        setTimeout(() => load(false), 2000);
+      }
     } finally {
       setLoading(false);
     }
@@ -20,7 +28,7 @@ export function useTasks() {
 
   useEffect(() => { load(); }, [load]);
 
-  return { tasks, loading, reload: load };
+  return { tasks, loading, error, reload: load };
 }
 
 export function useTimeline(limit = 50) {
@@ -30,10 +38,11 @@ export function useTimeline(limit = 50) {
   const load = useCallback(async () => {
     try {
       const res = await fetch(`/api/history?limit=${limit}`);
+      if (!res.ok) throw new Error(`HTTP ${res.status}`);
       const data = await res.json();
       setHistory(data.history ?? []);
     } catch {
-      // ignore
+      // エラー時は既存のhistoryを維持
     } finally {
       setLoading(false);
     }


### PR DESCRIPTION
## Summary
- Web UIがdaemonとのIPC接続を失った際、ブラウザリロードや再接続ボタンで復旧できるように改善
- daemon未接続時に「タスク作成」画面ではなく、専用の切断状態UIを表示するように変更

## Diff

### Before
```
ブラウザリロード
  → 半開きIPC接続にsend → 応答なし → ハング → タスク非表示
  → タスク0件として扱われ「最初のタスクを作成しましょう」が表示

make web を再起動しないと復旧できない
```

### After
```
ブラウザリロード
  → send 5秒タイムアウト → sendToIPC が接続リセット+リトライ → 復旧
  → 復旧失敗時は「デーモンに接続できません」+ 再接続ボタンを表示

                          ┌──────────────┐
                          │  Browser UI  │
                          └──────┬───────┘
                  fetch /api/tasks │ WebSocket
                                 │
                          ┌──────┴───────┐
                          │  Bun Server  │
                          └──────┬───────┘
               sendToIPC()       │  ← 失敗時1回リトライ
               (timeout: 5s)    │  ← 再接続時WSに通知
                          ┌──────┴───────┐
                          │   Daemon     │
                          └──────────────┘
```

**変更ファイル:**
- `ipc.ts`: `send()` に5秒タイムアウト追加
- `serve.ts`: `sendToIPC()` リトライヘルパー + `ensureIPC()` 再接続時WS通知
- `hooks.ts`: `res.ok` チェック + エラー時タスク保持 + 1回リトライ
- `App.tsx`: `DisconnectedView` コンポーネント追加
- `ipc.test.ts`: IPC タイムアウト/正常応答/未接続のテスト5件追加

## Test plan
- [x] `bun test src/ipc.test.ts` — 5テスト全パス
- [ ] daemon起動中にWeb UIを開き、タスクが正常表示されることを確認
- [ ] daemon停止中にWeb UIを開き、切断状態UIが表示されることを確認
- [ ] 切断状態UIの「再接続」ボタンでdaemon復旧後に正常表示に戻ることを確認
- [ ] daemon起動中にWeb UIを開き、daemonを再起動後ブラウザリロードでタスクが表示されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)