### PR TITLE
Web UI設定ページ追加 + デフォルトタイムアウト + UI改善

### DIFF
--- a/cli/src/serve.ts
+++ b/cli/src/serve.ts
@@ -126,6 +126,12 @@ async function handleAPI(req: Request): Promise<Response> {
       return Response.json(res);
     }
 
+    if (path === "/api/settings" && req.method === "POST") {
+      const body = await req.json();
+      const res = await sendToIPC({ action: "update_settings", settings: body });
+      return Response.json(res);
+    }
+
     return Response.json({ error: "見つかりません" }, { status: 404 });
   } catch (err) {
     return Response.json(

--- a/cli/src/web/App.tsx
+++ b/cli/src/web/App.tsx
@@ -1,11 +1,12 @@
 import React, { useState, useCallback } from "react";
-import { useTasks, useTimeline, useWebSocket, runTask, stopTask, saveTask, deleteTask } from "./hooks.ts";
+import { useTasks, useTimeline, useWebSocket, useSettings, runTask, stopTask, saveTask, deleteTask, updateSettings } from "./hooks.ts";
 import { TasksView } from "./TasksView.tsx";
 import { TimelineView } from "./TimelineView.tsx";
+import { SettingsView } from "./SettingsView.tsx";
 import { ToastContainer } from "./Toast.tsx";
 import type { TaskDefinition } from "./types.ts";
 
-type Tab = "tasks" | "timeline";
+type Tab = "tasks" | "timeline" | "settings";
 
 function DisconnectedView({ onRetry, retrying }: { onRetry: () => void; retrying: boolean }) {
   return (
@@ -38,6 +39,8 @@ export function App() {
   const [tab, setTab] = useState<Tab>("tasks");
   const { tasks, loading: tasksLoading, error: tasksError, reload: reloadTasks } = useTasks();
   const { history, reload: reloadTimeline } = useTimeline();
+  const { settings, loading: settingsLoading, reload: reloadSettings } = useSettings();
+  const [isNewTask, setIsNewTask] = useState(false);
   const [retrying, setRetrying] = useState(false);
 
   const handleMessage = useCallback(() => {
@@ -95,25 +98,43 @@ export function App() {
           <DisconnectedView onRetry={handleRetry} retrying={retrying} />
         ) : (
           <>
-            <div className="tabs">
-              <button
-                className={`tab ${tab === "tasks" ? "active" : ""}`}
-                onClick={() => setTab("tasks")}
-              >
-                タスク
-              </button>
-              <button
-                className={`tab ${tab === "timeline" ? "active" : ""}`}
-                onClick={() => setTab("timeline")}
-              >
-                実行ログ
-              </button>
+            <div className="tabs-toolbar">
+              <div className="tabs">
+                <button
+                  className={`tab ${tab === "tasks" ? "active" : ""}`}
+                  onClick={() => setTab("tasks")}
+                >
+                  タスク
+                </button>
+                <button
+                  className={`tab ${tab === "timeline" ? "active" : ""}`}
+                  onClick={() => setTab("timeline")}
+                >
+                  実行ログ
+                </button>
+                <button
+                  className={`tab ${tab === "settings" ? "active" : ""}`}
+                  onClick={() => setTab("settings")}
+                >
+                  設定
+                </button>
+              </div>
+              {tab === "tasks" && (
+                <button
+                  className="btn btn-primary"
+                  onClick={() => { setIsNewTask(true); }}
+                >
+                  + 新規タスク
+                </button>
+              )}
             </div>
 
             {tab === "tasks" && (
               <TasksView
                 tasks={tasks}
                 loading={tasksLoading}
+                isNewTask={isNewTask}
+                onNewTaskChange={setIsNewTask}
                 onRun={handleRun}
                 onStop={handleStop}
                 onSave={handleSave}
@@ -121,6 +142,17 @@ export function App() {
               />
             )}
             {tab === "timeline" && <TimelineView history={history} />}
+            {tab === "settings" && (
+              <SettingsView
+                settings={settings}
+                loading={settingsLoading}
+                onSave={async (s) => {
+                  const ok = await updateSettings(s);
+                  if (ok) reloadSettings();
+                  return ok;
+                }}
+              />
+            )}
           </>
         )}
       </main>

--- a/cli/src/web/SettingsView.tsx
+++ b/cli/src/web/SettingsView.tsx
@@ -1,0 +1,105 @@
+import React, { useState, useEffect, useRef } from "react";
+import type { GlobalSettings } from "./types.ts";
+
+interface Props {
+  settings: GlobalSettings | null;
+  loading: boolean;
+  onSave: (settings: GlobalSettings) => Promise<boolean>;
+}
+
+// GlobalSettings.defaultTimeoutValue (Swift側) と同期させること
+const DEFAULT_TIMEOUT = 3600;
+
+export function SettingsView({ settings, loading, onSave }: Props) {
+  const [webhookURL, setWebhookURL] = useState("");
+  const [defaultTimeout, setDefaultTimeout] = useState(DEFAULT_TIMEOUT);
+  const [saveStatus, setSaveStatus] = useState<"idle" | "saving" | "saved">("idle");
+
+  const initialized = useRef(false);
+
+  useEffect(() => {
+    if (!settings || initialized.current) return;
+    initialized.current = true;
+    setWebhookURL(settings.slack_webhook_url ?? "");
+    setDefaultTimeout(settings.default_timeout ?? DEFAULT_TIMEOUT);
+  }, [settings]);
+
+  // Auto-save on change (debounced)
+  const onSaveRef = useRef(onSave);
+  useEffect(() => { onSaveRef.current = onSave; });
+  const isFirstRender = useRef(true);
+
+  useEffect(() => {
+    if (!initialized.current) return;
+    if (isFirstRender.current) { isFirstRender.current = false; return; }
+
+    setSaveStatus("idle");
+    const timer = setTimeout(async () => {
+      setSaveStatus("saving");
+      const ok = await onSaveRef.current({
+        slack_webhook_url: webhookURL.trim() || undefined,
+        default_timeout: defaultTimeout > 0 ? defaultTimeout : undefined,
+      });
+      setSaveStatus(ok ? "saved" : "idle");
+    }, 600);
+
+    return () => clearTimeout(timer);
+  }, [webhookURL, defaultTimeout]);
+
+  if (loading) return null;
+
+  return (
+    <div className="settings-view">
+      <div className="settings-card">
+        <div className="settings-header">
+          <h2 className="settings-title">設定</h2>
+          <span className={`save-status ${saveStatus}`}>
+            {saveStatus === "saving" ? "保存中..." : saveStatus === "saved" ? "\u2713" : ""}
+          </span>
+        </div>
+
+        <div className="settings-section">
+          <h3 className="settings-section-title">全般</h3>
+          <div className="settings-field">
+            <label className="settings-label">デフォルトタイムアウト</label>
+            <div className="settings-field-row">
+              <input
+                className="form-input settings-timeout-input"
+                type="text"
+                inputMode="numeric"
+                value={defaultTimeout || ""}
+                onChange={(e) => {
+                  const n = parseInt(e.target.value.replace(/[^0-9]/g, ""), 10);
+                  setDefaultTimeout(n > 0 ? n : 0);
+                }}
+                placeholder={String(DEFAULT_TIMEOUT)}
+              />
+              <span className="field-hint-inline">秒</span>
+            </div>
+            <div className="field-hint-small">
+              タスクごとのタイムアウトが設定されている場合はそちらが優先されます。
+              デフォルト: {DEFAULT_TIMEOUT} 秒（1時間）
+            </div>
+          </div>
+        </div>
+
+        <div className="settings-section">
+          <h3 className="settings-section-title">Slack 通知</h3>
+          <div className="settings-field">
+            <label className="settings-label">Webhook URL</label>
+            <input
+              className="form-input"
+              type="text"
+              value={webhookURL}
+              onChange={(e) => setWebhookURL(e.target.value)}
+              placeholder="https://hooks.slack.com/services/..."
+            />
+            <div className="field-hint-small">
+              タスクの「失敗時に通知」が有効な場合、失敗・タイムアウト時にこの Webhook に通知が送信されます。
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/cli/src/web/TasksView.test.ts
+++ b/cli/src/web/TasksView.test.ts
@@ -1,0 +1,58 @@
+import { describe, expect, test } from "bun:test";
+import { resolveHome, shortenDir } from "./TasksView.tsx";
+
+describe("resolveHome", () => {
+  test("replaces /Users/username with ~", () => {
+    expect(resolveHome("/Users/shingo/projects")).toBe("~/projects");
+  });
+
+  test("handles nested paths", () => {
+    expect(resolveHome("/Users/alice/a/b/c")).toBe("~/a/b/c");
+  });
+
+  test("does not modify paths already using ~", () => {
+    expect(resolveHome("~/projects/myapp")).toBe("~/projects/myapp");
+  });
+
+  test("does not modify unrelated absolute paths", () => {
+    expect(resolveHome("/usr/local/bin")).toBe("/usr/local/bin");
+  });
+
+  test("handles bare home directory", () => {
+    expect(resolveHome("/Users/shingo")).toBe("~");
+  });
+
+  test("handles ~", () => {
+    expect(resolveHome("~")).toBe("~");
+  });
+});
+
+describe("shortenDir", () => {
+  test("returns full path for 1 segment", () => {
+    expect(shortenDir("~")).toBe("~");
+  });
+
+  test("returns full path for 2 segments", () => {
+    expect(shortenDir("~/projects")).toBe("~/projects");
+  });
+
+  test("returns full path for 3 segments", () => {
+    expect(shortenDir("~/projects/myapp")).toBe("~/projects/myapp");
+  });
+
+  test("returns last 2 segments for 4+ segments", () => {
+    expect(shortenDir("~/a/b/c")).toBe("b/c");
+  });
+
+  test("returns last 2 segments for deeply nested path", () => {
+    expect(shortenDir("~/projects/github.com/user/repo")).toBe("user/repo");
+  });
+
+  test("resolves /Users/ before shortening", () => {
+    expect(shortenDir("/Users/shingo/projects/github.com/user/repo")).toBe("user/repo");
+  });
+
+  test("/Users/shingo/projects/myapp resolves to 3 segments and shows full", () => {
+    expect(shortenDir("/Users/shingo/projects/myapp")).toBe("~/projects/myapp");
+  });
+});

--- a/cli/src/web/TasksView.tsx
+++ b/cli/src/web/TasksView.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect, useCallback, useRef } from "react";
+import React, { useState, useEffect, useCallback, useRef, useMemo } from "react";
 import type { TaskStatus, TaskDefinition, ExecutionRecord, Schedule } from "./types.ts";
 import { formatDate, formatDuration, formatSchedule, statusIcon } from "./format.ts";
 import { LogModal } from "./LogViewer.tsx";
@@ -9,6 +9,8 @@ import { useCountdown } from "./hooks.ts";
 interface Props {
   tasks: TaskStatus[];
   loading: boolean;
+  isNewTask: boolean;
+  onNewTaskChange: (v: boolean) => void;
   onRun: (id: string) => void;
   onStop: (id: string) => void;
   onSave: (task: TaskDefinition) => Promise<boolean>;
@@ -96,6 +98,37 @@ function TaskListItem({ task, selected, onSelect }: {
       )}
     </div>
   );
+}
+
+// --- Directory grouping ---
+
+interface TaskGroup {
+  dir: string;
+  label: string;
+  tasks: TaskStatus[];
+}
+
+/** /Users/username/... → ~/... */
+export function resolveHome(dir: string): string {
+  return dir.replace(/^\/Users\/[^/]+/, "~");
+}
+
+/** ~/a/b/c/d → c/d (4セグメント以上は末尾2つ、3つ以下はそのまま) */
+export function shortenDir(dir: string): string {
+  const resolved = resolveHome(dir);
+  const parts = resolved.split("/").filter((p) => p !== "");
+  if (parts.length <= 3) return resolved;
+  return parts.slice(-2).join("/");
+}
+
+function groupByDirectory(tasks: TaskStatus[]): TaskGroup[] {
+  const map = new Map<string, TaskStatus[]>();
+  for (const t of tasks) {
+    const dir = resolveHome(t.task.working_directory || "~");
+    if (!map.has(dir)) map.set(dir, []);
+    map.get(dir)!.push(t);
+  }
+  return Array.from(map, ([dir, tasks]) => ({ dir, label: shortenDir(dir), tasks }));
 }
 
 // --- Constants ---
@@ -195,24 +228,26 @@ function NumInput({ value, onChange, min, max, className }: {
   );
 }
 
-// --- Detail Panel ---
+// --- Task Form Fields (shared between detail panel and new task modal) ---
 
-interface DetailProps {
-  task?: TaskDefinition;
-  taskStatus?: TaskStatus;
-  isNew: boolean;
-  onSave: (task: TaskDefinition) => Promise<boolean>;
-  onRun: () => void;
-  onStop: () => void;
-  onDelete: () => void;
+interface TaskFormState {
+  name: string; setName: (v: string) => void;
+  command: string; setCommand: (v: string) => void;
+  workingDirectory: string; setWorkingDirectory: (v: string) => void;
+  dirError: string | null; setDirError: (v: string | null) => void;
+  dirValidating: React.MutableRefObject<boolean>;
+  catchUp: boolean; setCatchUp: (v: boolean) => void;
+  notifyOnFailure: boolean; setNotifyOnFailure: (v: boolean) => void;
+  timeout: number; setTimeout_: (v: number) => void;
+  scheduleType: string; setScheduleType: (v: string) => void;
+  hour: number; setHour: (v: number) => void;
+  minute: number; setMinute: (v: number) => void;
+  weekdays: number[]; toggleWeekday: (d: number) => void;
+  monthDays: number[]; toggleMonthDay: (d: number) => void;
+  cronExpr: string; setCronExpr: (v: string) => void;
 }
 
-const LOG_PAGE_SIZE = 15;
-
-function TaskDetailPanel({ task, taskStatus, isNew, onSave, onRun, onStop, onDelete }: DetailProps) {
-  const countdown = useCountdown(taskStatus?.nextRunAt);
-  const [autoId] = useState(() => generateId());
-
+function useTaskForm(task?: TaskDefinition): TaskFormState {
   const [name, setName] = useState(task?.name ?? "");
   const [command, setCommand] = useState(task?.command ?? "");
   const [workingDirectory, setWorkingDirectory] = useState(task?.working_directory ?? "");
@@ -252,7 +287,252 @@ function TaskDetailPanel({ task, taskStatus, isNew, onSave, onRun, onStop, onDel
     });
   };
 
-  const [creating, setCreating] = useState(false);
+  return {
+    name, setName, command, setCommand,
+    workingDirectory, setWorkingDirectory, dirError, setDirError, dirValidating,
+    catchUp, setCatchUp, notifyOnFailure, setNotifyOnFailure, timeout, setTimeout_,
+    scheduleType, setScheduleType, hour, setHour, minute, setMinute,
+    weekdays, toggleWeekday, monthDays, toggleMonthDay, cronExpr, setCronExpr,
+  };
+}
+
+function buildTaskObj(form: TaskFormState, id: string, enabled: boolean): TaskDefinition {
+  return {
+    id,
+    name: form.name.trim(),
+    command: form.command,
+    working_directory: form.workingDirectory.trim() || undefined,
+    schedule: buildSchedule(form.scheduleType, form.hour, form.minute, form.weekdays, form.monthDays, form.cronExpr),
+    enabled,
+    catch_up: form.catchUp,
+    notify_on_failure: form.notifyOnFailure,
+    timeout: form.timeout > 0 ? form.timeout : undefined,
+  };
+}
+
+function TaskFormFields({ form }: { form: TaskFormState }) {
+  return (
+    <>
+      <div className="detail-section">
+        <label className="detail-label">実行コマンド</label>
+        <textarea
+          className="form-textarea"
+          value={form.command}
+          onChange={(e) => form.setCommand(e.target.value)}
+          placeholder="echo 'hello world'"
+          rows={6}
+          autoComplete="off"
+          data-1p-ignore
+        />
+      </div>
+
+      <div className="detail-section">
+        <label className="detail-label">実行ディレクトリ</label>
+        <input
+          className={`form-input ${form.dirError ? "input-error" : ""}`}
+          type="text"
+          value={form.workingDirectory}
+          onChange={(e) => { form.setWorkingDirectory(e.target.value); form.setDirError(null); }}
+          autoComplete="off"
+          data-1p-ignore
+          onBlur={async () => {
+            const trimmed = form.workingDirectory.trim();
+            if (!trimmed) { form.setDirError(null); return; }
+            form.dirValidating.current = true;
+            try {
+              const res = await fetch(`/api/check-dir?path=${encodeURIComponent(trimmed)}`);
+              const data = await res.json();
+              form.setDirError(data.exists ? null : "ディレクトリが存在しません");
+            } catch {
+              form.setDirError(null);
+            } finally {
+              form.dirValidating.current = false;
+            }
+          }}
+          placeholder="~/projects/myapp"
+        />
+        {form.dirError && <div className="field-error">{form.dirError}</div>}
+        <div className="field-hint-small">※ 省略時はホームディレクトリで実行されます</div>
+      </div>
+
+      <div className="detail-section">
+        <label className="detail-label">実行スケジュール (JST)</label>
+        <div className="sched">
+          <div className="sched-pills">
+            {SCHEDULE_TYPES.map((st) => (
+              <button
+                key={st.value}
+                type="button"
+                className={`sched-pill ${form.scheduleType === st.value ? "active" : ""}`}
+                onClick={() => form.setScheduleType(st.value)}
+              >
+                {st.label}
+              </button>
+            ))}
+          </div>
+
+          {form.scheduleType === "every_minute" && (
+            <div className="sched-hint">毎分実行されます</div>
+          )}
+
+          {form.scheduleType === "hourly" && (
+            <div className="sched-sentence">
+              毎時
+              <div className="sched-time-box">
+                <NumInput className="sched-time-m" min={0} max={59} value={form.minute} onChange={form.setMinute} />
+              </div>
+              分に実行
+            </div>
+          )}
+
+          {form.scheduleType === "daily" && (
+            <div className="sched-sentence">
+              毎日
+              <div className="sched-time-box">
+                <NumInput className="sched-time-h" min={0} max={23} value={form.hour} onChange={form.setHour} />
+                <span className="sched-time-sep">:</span>
+                <NumInput className="sched-time-m" min={0} max={59} value={form.minute} onChange={form.setMinute} />
+              </div>
+              に実行
+            </div>
+          )}
+
+          {form.scheduleType === "weekly" && (
+            <>
+              <div className="sched-weekdays">
+                {WEEKDAYS.map((d) => (
+                  <button
+                    key={d.value}
+                    type="button"
+                    className={`weekday-pill ${form.weekdays.includes(d.value) ? "active" : ""}`}
+                    onClick={() => form.toggleWeekday(d.value)}
+                  >
+                    {d.label}
+                  </button>
+                ))}
+              </div>
+              <div className="sched-sentence">
+                <div className="sched-time-box">
+                  <NumInput className="sched-time-h" min={0} max={23} value={form.hour} onChange={form.setHour} />
+                  <span className="sched-time-sep">:</span>
+                  <NumInput className="sched-time-m" min={0} max={59} value={form.minute} onChange={form.setMinute} />
+                </div>
+                に実行
+              </div>
+            </>
+          )}
+
+          {form.scheduleType === "monthly" && (
+            <>
+              <div className="sched-monthdays">
+                {MONTH_DAYS.map((d) => (
+                  <button
+                    key={d}
+                    type="button"
+                    className={`monthday-pill ${form.monthDays.includes(d) ? "active" : ""}`}
+                    onClick={() => form.toggleMonthDay(d)}
+                  >
+                    {d}
+                  </button>
+                ))}
+                <button
+                  type="button"
+                  className={`monthday-pill last-day ${form.monthDays.includes(-1) ? "active" : ""}`}
+                  onClick={() => form.toggleMonthDay(-1)}
+                >
+                  月末
+                </button>
+              </div>
+              <div className="sched-sentence">
+                <div className="sched-time-box">
+                  <NumInput className="sched-time-h" min={0} max={23} value={form.hour} onChange={form.setHour} />
+                  <span className="sched-time-sep">:</span>
+                  <NumInput className="sched-time-m" min={0} max={59} value={form.minute} onChange={form.setMinute} />
+                </div>
+                に実行
+              </div>
+            </>
+          )}
+
+          {form.scheduleType === "cron" && (
+            <input
+              className="form-input sched-cron"
+              type="text"
+              value={form.cronExpr}
+              onChange={(e) => form.setCronExpr(e.target.value)}
+              placeholder="*/15 * * * *"
+              autoComplete="off"
+              data-1p-ignore
+            />
+          )}
+        </div>
+      </div>
+
+      <div className="detail-section">
+        <label className="detail-label">オプション</label>
+        <div className="checkbox-group">
+          <label className="checkbox-label">
+            <input type="checkbox" checked={form.catchUp} onChange={(e) => form.setCatchUp(e.target.checked)} />
+            スリープ復帰時に未実行分を1回実行
+            <span className="tooltip-wrap">
+              <span className="tooltip-hint">?</span>
+              <span className="tooltip-bubble">
+                スリープ復帰時に、実行されなかったスケジュールがあれば <strong>1回だけ</strong> 再実行します。複数回分溜まっていても実行は1回です。
+                <br /><br />
+                遡る範囲は直前のスリープ期間のみです。
+                <br /><br />
+                例: 毎朝 08:00 のタスクで 11:00 に復帰 → 即座に1回実行
+              </span>
+            </span>
+          </label>
+          <label className="checkbox-label">
+            <input type="checkbox" checked={form.notifyOnFailure} onChange={(e) => form.setNotifyOnFailure(e.target.checked)} />
+            失敗時に通知 (Slack)
+          </label>
+        </div>
+        <div className="timeout-row">
+          <label className="detail-label-inline">タイムアウト</label>
+          <input
+            className="form-input timeout-input"
+            type="text"
+            inputMode="numeric"
+            value={form.timeout || ""}
+            onChange={(e) => {
+              const n = parseInt(e.target.value.replace(/[^0-9]/g, ""), 10);
+              form.setTimeout_(n > 0 ? n : 0);
+            }}
+            placeholder="なし"
+          />
+          <span className="field-hint-inline">秒</span>
+          <span className="tooltip-wrap">
+            <span className="tooltip-hint">?</span>
+            <span className="tooltip-bubble">
+              設定するとデフォルトタイムアウトより優先されます。
+            </span>
+          </span>
+        </div>
+      </div>
+    </>
+  );
+}
+
+// --- Detail Panel (editing existing tasks) ---
+
+interface DetailProps {
+  task: TaskDefinition;
+  taskStatus: TaskStatus;
+  onSave: (task: TaskDefinition) => Promise<boolean>;
+  onRun: () => void;
+  onStop: () => void;
+  onDelete: () => void;
+}
+
+const LOG_PAGE_SIZE = 15;
+
+function TaskDetailPanel({ task, taskStatus, onSave, onRun, onStop, onDelete }: DetailProps) {
+  const countdown = useCountdown(taskStatus.nextRunAt);
+  const form = useTaskForm(task);
+
   const [saveStatus, setSaveStatus] = useState<"idle" | "saving" | "saved">("idle");
 
   // History
@@ -262,7 +542,6 @@ function TaskDetailPanel({ task, taskStatus, isNew, onSave, onRun, onStop, onDel
   const [viewingLog, setViewingLog] = useState<ExecutionRecord | null>(null);
 
   const loadHistory = useCallback(async (limit: number) => {
-    if (!task?.id) return;
     try {
       const res = await fetch(`/api/history?taskId=${task.id}&limit=${limit + 1}`);
       const data = await res.json();
@@ -271,38 +550,27 @@ function TaskDetailPanel({ task, taskStatus, isNew, onSave, onRun, onStop, onDel
       setHasMore(records.length > limit);
       setHistory(records.slice(0, limit));
     } catch { /* ignore */ }
-  }, [task?.id]);
+  }, [task.id]);
 
   useEffect(() => {
     loadHistory(historyLimit);
-  }, [loadHistory, historyLimit, taskStatus?.lastRun?.id, taskStatus?.isRunning]);
+  }, [loadHistory, historyLimit, taskStatus.lastRun?.id, taskStatus.isRunning]);
 
   const handleLoadMore = () => {
     setHistoryLimit((prev) => prev + LOG_PAGE_SIZE);
   };
 
-  // --- Auto-save (existing tasks only) ---
+  // --- Auto-save ---
   const onSaveRef = useRef(onSave);
   useEffect(() => { onSaveRef.current = onSave; });
   const isFirstRender = useRef(true);
 
   useEffect(() => {
-    if (isNew || !task?.id) return;
     if (isFirstRender.current) { isFirstRender.current = false; return; }
-    if (!name.trim() || !command || dirValidating.current) { setSaveStatus("idle"); return; }
+    if (!form.name.trim() || !form.command || form.dirValidating.current) { setSaveStatus("idle"); return; }
 
     setSaveStatus("idle");
-    const taskObj: TaskDefinition = {
-      id: task.id,
-      name: name.trim(),
-      command,
-      working_directory: workingDirectory.trim() || undefined,
-      schedule: buildSchedule(scheduleType, hour, minute, weekdays, monthDays, cronExpr),
-      enabled: task.enabled,
-      catch_up: catchUp,
-      notify_on_failure: notifyOnFailure,
-      timeout: timeout > 0 ? timeout : undefined,
-    };
+    const taskObj = buildTaskObj(form, task.id, task.enabled);
 
     const timer = setTimeout(async () => {
       setSaveStatus("saving");
@@ -312,24 +580,7 @@ function TaskDetailPanel({ task, taskStatus, isNew, onSave, onRun, onStop, onDel
 
     return () => clearTimeout(timer);
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [isNew, task?.id, name, command, workingDirectory, scheduleType, hour, minute, JSON.stringify(weekdays), JSON.stringify(monthDays), cronExpr, catchUp, notifyOnFailure, timeout]);
-
-  // --- Create (new tasks only) ---
-  const handleCreate = async () => {
-    setCreating(true);
-    await onSave({
-      id: autoId,
-      name: name.trim(),
-      command,
-      working_directory: workingDirectory.trim() || undefined,
-      schedule: buildSchedule(scheduleType, hour, minute, weekdays, monthDays, cronExpr),
-      enabled: true,
-      catch_up: catchUp,
-      notify_on_failure: notifyOnFailure,
-      timeout: timeout > 0 ? timeout : undefined,
-    });
-    setCreating(false);
-  };
+  }, [task.id, form.name, form.command, form.workingDirectory, form.scheduleType, form.hour, form.minute, JSON.stringify(form.weekdays), JSON.stringify(form.monthDays), form.cronExpr, form.catchUp, form.notifyOnFailure, form.timeout]);
 
   return (
     <div className="detail-panel">
@@ -337,268 +588,141 @@ function TaskDetailPanel({ task, taskStatus, isNew, onSave, onRun, onStop, onDel
         <input
           className="detail-name-input"
           type="text"
-          value={name}
-          onChange={(e) => setName(e.target.value)}
+          value={form.name}
+          onChange={(e) => form.setName(e.target.value)}
           placeholder="タスク名"
-          autoFocus={isNew}
+          autoComplete="off"
+          data-1p-ignore
         />
         <div className="detail-header-actions">
-          {!isNew && (
-            <span className={`save-status ${saveStatus}`}>
-              {saveStatus === "saving" ? "保存中..." : saveStatus === "saved" ? "\u2713" : ""}
-            </span>
-          )}
-          {!isNew && taskStatus && (
-            taskStatus.isRunning ? (
-              <button className="btn btn-stop" onClick={onStop}><StopIcon />停止</button>
-            ) : (
-              <button className="btn btn-run" onClick={onRun}><PlayIcon />実行</button>
-            )
-          )}
-          {isNew && (
-            <button
-              className="btn btn-primary"
-              onClick={handleCreate}
-              disabled={creating || !name.trim() || !command}
-            >
-              作成
-            </button>
+          <span className={`save-status ${saveStatus}`}>
+            {saveStatus === "saving" ? "保存中..." : saveStatus === "saved" ? "\u2713" : ""}
+          </span>
+          {taskStatus.isRunning ? (
+            <button className="btn btn-stop" onClick={onStop}><StopIcon />停止</button>
+          ) : (
+            <button className="btn btn-run" onClick={onRun}><PlayIcon />実行</button>
           )}
         </div>
       </div>
 
-      <div className={`detail-body ${!isNew ? "two-col" : ""}`}>
+      <div className="detail-body two-col">
         <div className="detail-col-form">
-          <div className="detail-section">
-            <label className="detail-label">実行コマンド</label>
-            <textarea
-              className="form-textarea"
-              value={command}
-              onChange={(e) => setCommand(e.target.value)}
-              placeholder="echo 'hello world'"
-              rows={6}
-            />
+          <TaskFormFields form={form} />
+          <div className="detail-section detail-delete">
+            <button className="btn btn-danger-ghost" onClick={onDelete}>
+              <TrashIcon />タスクを削除
+            </button>
           </div>
-
-          <div className="detail-section">
-            <label className="detail-label">実行ディレクトリ</label>
-            <input
-              className={`form-input ${dirError ? "input-error" : ""}`}
-              type="text"
-              value={workingDirectory}
-              onChange={(e) => { setWorkingDirectory(e.target.value); setDirError(null); }}
-              onBlur={async () => {
-                const trimmed = workingDirectory.trim();
-                if (!trimmed) { setDirError(null); return; }
-                dirValidating.current = true;
-                try {
-                  const res = await fetch(`/api/check-dir?path=${encodeURIComponent(trimmed)}`);
-                  const data = await res.json();
-                  setDirError(data.exists ? null : "ディレクトリが存在しません");
-                } catch {
-                  setDirError(null);
-                } finally {
-                  dirValidating.current = false;
-                }
-              }}
-              placeholder="~/projects/myapp"
-            />
-            {dirError && <div className="field-error">{dirError}</div>}
-            <div className="field-hint-small">※ 省略時はホームディレクトリで実行されます</div>
-          </div>
-
-          <div className="detail-section">
-            <label className="detail-label">実行スケジュール (JST)</label>
-            <div className="sched">
-              <div className="sched-pills">
-                {SCHEDULE_TYPES.map((st) => (
-                  <button
-                    key={st.value}
-                    type="button"
-                    className={`sched-pill ${scheduleType === st.value ? "active" : ""}`}
-                    onClick={() => setScheduleType(st.value)}
-                  >
-                    {st.label}
-                  </button>
-                ))}
-              </div>
-
-              {scheduleType === "every_minute" && (
-                <div className="sched-hint">毎分実行されます</div>
-              )}
-
-              {scheduleType === "hourly" && (
-                <div className="sched-sentence">
-                  毎時
-                  <div className="sched-time-box">
-                    <NumInput className="sched-time-m" min={0} max={59} value={minute} onChange={setMinute} />
-                  </div>
-                  分に実行
-                </div>
-              )}
-
-              {scheduleType === "daily" && (
-                <div className="sched-sentence">
-                  毎日
-                  <div className="sched-time-box">
-                    <NumInput className="sched-time-h" min={0} max={23} value={hour} onChange={setHour} />
-                    <span className="sched-time-sep">:</span>
-                    <NumInput className="sched-time-m" min={0} max={59} value={minute} onChange={setMinute} />
-                  </div>
-                  に実行
-                </div>
-              )}
-
-              {scheduleType === "weekly" && (
-                <>
-                  <div className="sched-weekdays">
-                    {WEEKDAYS.map((d) => (
-                      <button
-                        key={d.value}
-                        type="button"
-                        className={`weekday-pill ${weekdays.includes(d.value) ? "active" : ""}`}
-                        onClick={() => toggleWeekday(d.value)}
-                      >
-                        {d.label}
-                      </button>
-                    ))}
-                  </div>
-                  <div className="sched-sentence">
-                    <div className="sched-time-box">
-                      <NumInput className="sched-time-h" min={0} max={23} value={hour} onChange={setHour} />
-                      <span className="sched-time-sep">:</span>
-                      <NumInput className="sched-time-m" min={0} max={59} value={minute} onChange={setMinute} />
-                    </div>
-                    に実行
-                  </div>
-                </>
-              )}
-
-              {scheduleType === "monthly" && (
-                <>
-                  <div className="sched-monthdays">
-                    {MONTH_DAYS.map((d) => (
-                      <button
-                        key={d}
-                        type="button"
-                        className={`monthday-pill ${monthDays.includes(d) ? "active" : ""}`}
-                        onClick={() => toggleMonthDay(d)}
-                      >
-                        {d}
-                      </button>
-                    ))}
-                    <button
-                      type="button"
-                      className={`monthday-pill last-day ${monthDays.includes(-1) ? "active" : ""}`}
-                      onClick={() => toggleMonthDay(-1)}
-                    >
-                      月末
-                    </button>
-                  </div>
-                  <div className="sched-sentence">
-                    <div className="sched-time-box">
-                      <NumInput className="sched-time-h" min={0} max={23} value={hour} onChange={setHour} />
-                      <span className="sched-time-sep">:</span>
-                      <NumInput className="sched-time-m" min={0} max={59} value={minute} onChange={setMinute} />
-                    </div>
-                    に実行
-                  </div>
-                </>
-              )}
-
-              {scheduleType === "cron" && (
-                <input
-                  className="form-input sched-cron"
-                  type="text"
-                  value={cronExpr}
-                  onChange={(e) => setCronExpr(e.target.value)}
-                  placeholder="*/15 * * * *"
-                />
-              )}
-            </div>
-          </div>
-
-          <div className="detail-section">
-            <label className="detail-label">オプション</label>
-            <div className="checkbox-group">
-              <label className="checkbox-label">
-                <input type="checkbox" checked={catchUp} onChange={(e) => setCatchUp(e.target.checked)} />
-                スリープ復帰時に未実行分を1回実行
-                <span className="tooltip-wrap">
-                  <span className="tooltip-hint">?</span>
-                  <span className="tooltip-bubble">
-                    スリープ復帰時に、実行されなかったスケジュールがあれば <strong>1回だけ</strong> 再実行します。複数回分溜まっていても実行は1回です。
-                    <br /><br />
-                    遡る範囲は直前のスリープ期間のみです。
-                    <br /><br />
-                    例: 毎朝 08:00 のタスクで 11:00 に復帰 → 即座に1回実行
-                  </span>
-                </span>
-              </label>
-              <label className="checkbox-label">
-                <input type="checkbox" checked={notifyOnFailure} onChange={(e) => setNotifyOnFailure(e.target.checked)} />
-                失敗時に通知 (Slack)
-              </label>
-            </div>
-            <div className="timeout-row">
-              <label className="detail-label-inline">タイムアウト</label>
-              <input
-                className="form-input timeout-input"
-                type="text"
-                inputMode="numeric"
-                value={timeout || ""}
-                onChange={(e) => {
-                  const n = parseInt(e.target.value.replace(/[^0-9]/g, ""), 10);
-                  setTimeout_(n > 0 ? n : 0);
-                }}
-                placeholder="なし"
-              />
-              <span className="field-hint-inline">秒</span>
-            </div>
-          </div>
-
-          {!isNew && (
-            <div className="detail-section detail-delete">
-              <button className="btn btn-danger-ghost" onClick={onDelete}>
-                <TrashIcon />タスクを削除
-              </button>
-            </div>
-          )}
         </div>
 
-        {!isNew && (
-          <div className="detail-col-log">
-            {taskStatus?.nextRunAt && (
-              <div className="detail-section">
-                <label className="detail-label">次回実行</label>
-                <span className="next-run-badge">
-                  {formatDate(taskStatus.nextRunAt)}
-                  {countdown && <span className="next-run-countdown">（{countdown}）</span>}
-                </span>
-              </div>
-            )}
-            <label className="detail-label">実行ログ</label>
-            {history.length > 0 ? (
-              <div className="log-list">
-                {history.map((r) => (
-                  <LogRow key={r.id} record={r} onClick={() => setViewingLog(r)} />
-                ))}
-                {hasMore && (
-                  <button className="load-more-btn" onClick={handleLoadMore}>
-                    もっと読み込む
-                  </button>
-                )}
-              </div>
-            ) : (
-              <div className="log-empty-hint">まだ実行されていません</div>
-            )}
-          </div>
-        )}
+        <div className="detail-col-log">
+          {taskStatus.nextRunAt && (
+            <div className="detail-section">
+              <label className="detail-label">次回実行</label>
+              <span className="next-run-badge">
+                {formatDate(taskStatus.nextRunAt)}
+                {countdown && <span className="next-run-countdown">（{countdown}）</span>}
+              </span>
+            </div>
+          )}
+          <label className="detail-label">実行ログ</label>
+          {history.length > 0 ? (
+            <div className="log-list">
+              {history.map((r) => (
+                <LogRow key={r.id} record={r} onClick={() => setViewingLog(r)} />
+              ))}
+              {hasMore && (
+                <button className="load-more-btn" onClick={handleLoadMore}>
+                  もっと読み込む
+                </button>
+              )}
+            </div>
+          ) : (
+            <div className="log-empty-hint">まだ実行されていません</div>
+          )}
+        </div>
       </div>
 
       {viewingLog && (
         <LogModal record={viewingLog} onClose={() => setViewingLog(null)} />
       )}
+    </div>
+  );
+}
+
+// --- New Task Modal ---
+
+function NewTaskModal({ onSave, onClose }: {
+  onSave: (task: TaskDefinition) => Promise<boolean>;
+  onClose: () => void;
+}) {
+  const [autoId] = useState(() => generateId());
+  const form = useTaskForm();
+  const [creating, setCreating] = useState(false);
+
+  const hasContent = form.name.trim() !== "" || form.command !== "";
+  const canCreate = form.name.trim() !== "" && form.command !== "";
+
+  // モーダル表示中は背後のスクロールを無効化
+  useEffect(() => {
+    document.body.style.overflow = "hidden";
+    return () => { document.body.style.overflow = ""; };
+  }, []);
+
+  const handleClose = () => {
+    if (hasContent && !confirm("入力内容が保存されていません。\n入力内容が消えますが、よろしいですか？")) return;
+    onClose();
+  };
+
+  const handleCreate = async () => {
+    setCreating(true);
+    const ok = await onSave(buildTaskObj(form, autoId, true));
+    setCreating(false);
+    if (ok) onClose();
+  };
+
+  const handleCloseRef = useRef(handleClose);
+  handleCloseRef.current = handleClose;
+  useEffect(() => {
+    const onKey = (e: KeyboardEvent) => { if (e.key === "Escape") handleCloseRef.current(); };
+    window.addEventListener("keydown", onKey);
+    return () => window.removeEventListener("keydown", onKey);
+  }, []);
+
+  return (
+    <div className="modal-overlay" onClick={handleClose}>
+      <div className="modal modal-new-task" onClick={(e) => e.stopPropagation()}>
+        <div className="modal-header">
+          <h2>新規タスク</h2>
+          <button className="modal-close" onClick={handleClose}>&times;</button>
+        </div>
+        <div className="modal-body">
+          <div className="detail-section">
+            <label className="detail-label">タスク名</label>
+            <input
+              className="form-input"
+              type="text"
+              value={form.name}
+              onChange={(e) => form.setName(e.target.value)}
+              placeholder="タスク名"
+              autoFocus
+              autoComplete="off"
+              data-1p-ignore
+            />
+          </div>
+          <TaskFormFields form={form} />
+        </div>
+        <div className="modal-footer">
+          <button
+            className="btn btn-primary"
+            onClick={handleCreate}
+            disabled={creating || !canCreate}
+          >
+            作成
+          </button>
+        </div>
+      </div>
     </div>
   );
 }
@@ -618,8 +742,8 @@ function EmptyState({ onCreate }: { onCreate: () => void }) {
         <h2 className="onboarding-title">最初のタスクを作成しましょう</h2>
         <p className="onboarding-desc">
           コマンドの定期実行をスケジュールできます。<br />
-          バックアップ、デプロイ、ヘルスチェックなど、<br />
-          繰り返し実行したいタスクを登録してみましょう。
+          エージェントの定期実行、毎日の情報収集など、<br />
+          自動化したいタスクを登録してみましょう。
         </p>
         <button className="btn btn-primary onboarding-cta" onClick={onCreate}>
           + 最初のタスクを作成
@@ -629,107 +753,88 @@ function EmptyState({ onCreate }: { onCreate: () => void }) {
   );
 }
 
-function OnboardingForm({ onSave }: { onSave: (task: TaskDefinition) => Promise<boolean> }) {
-  return (
-    <div className="onboarding-form-wrap">
-      <TaskDetailPanel
-        isNew
-        onSave={onSave}
-        onRun={() => {}}
-        onStop={() => {}}
-        onDelete={() => {}}
-      />
-    </div>
-  );
-}
-
 // --- Main View ---
 
-export function TasksView({ tasks, loading, onRun, onStop, onSave, onDelete }: Props) {
+export function TasksView({ tasks, loading, isNewTask, onNewTaskChange, onRun, onStop, onSave, onDelete }: Props) {
   const [selectedId, setSelectedId] = useState<string | null>(null);
-  const [isNew, setIsNew] = useState(false);
+
+  const groups = useMemo(() => groupByDirectory(tasks), [tasks]);
 
   // タスクがあるのに未選択なら最初のタスクを自動選択
-  const effectiveId = selectedId ?? (tasks.length > 0 && !isNew ? tasks[0]!.task.id : null);
-  const selectedTask = isNew ? undefined : tasks.find((t) => t.task.id === effectiveId);
+  const effectiveId = selectedId ?? (tasks.length > 0 ? tasks[0]!.task.id : null);
+  const selectedTask = effectiveId ? tasks.find((t) => t.task.id === effectiveId) : undefined;
 
   // Clear selection if selected task was deleted
   useEffect(() => {
-    if (selectedId && !isNew && !tasks.find((t) => t.task.id === selectedId)) {
+    if (selectedId && !tasks.find((t) => t.task.id === selectedId)) {
       setSelectedId(null);
     }
-  }, [tasks, selectedId, isNew]);
+  }, [tasks, selectedId]);
 
   // --- Loading ---
   if (loading) return null;
 
   // --- Empty state: no tasks ---
-  if (tasks.length === 0 && !selectedId) {
-    if (isNew) {
-      return (
-        <OnboardingForm
-          onSave={async (task) => {
-            const ok = await onSave(task);
-            if (ok) {
-              setSelectedId(task.id);
-              setIsNew(false);
-            }
-            return ok;
-          }}
-        />
-      );
-    }
-    return <EmptyState onCreate={() => setIsNew(true)} />;
+  if (tasks.length === 0) {
+    return (
+      <>
+        <EmptyState onCreate={() => onNewTaskChange(true)} />
+        {isNewTask && (
+          <NewTaskModal
+            onSave={onSave}
+            onClose={() => onNewTaskChange(false)}
+          />
+        )}
+      </>
+    );
   }
 
   // --- Normal master-detail ---
   return (
-    <div className="master-detail">
-      <div className="task-list-panel">
-        <button
-          className="btn btn-primary new-task-btn"
-          onClick={() => { setIsNew(true); setSelectedId(null); }}
-        >
-          + 新規タスク
-        </button>
-        <div className="task-list">
-          {tasks.map((t) => (
-            <TaskListItem
-              key={t.task.id}
-              task={t}
-              selected={t.task.id === effectiveId && !isNew}
-              onSelect={() => { setSelectedId(t.task.id); setIsNew(false); }}
+    <>
+      <div className="master-detail">
+        <div className="task-list-panel">
+          <div className="task-list">
+            {groups.map((group) => (
+              <div key={group.dir} className="task-group">
+                <div className="task-group-header" title={group.dir}>{group.label}</div>
+                {group.tasks.map((t) => (
+                  <TaskListItem
+                    key={t.task.id}
+                    task={t}
+                    selected={t.task.id === effectiveId}
+                    onSelect={() => setSelectedId(t.task.id)}
+                  />
+                ))}
+              </div>
+            ))}
+          </div>
+        </div>
+
+        <div className="task-detail-panel">
+          {selectedTask && (
+            <TaskDetailPanel
+              key={effectiveId}
+              task={selectedTask.task}
+              taskStatus={selectedTask}
+              onSave={onSave}
+              onRun={() => onRun(selectedTask.task.id)}
+              onStop={() => onStop(selectedTask.task.id)}
+              onDelete={() => {
+                onDelete(selectedTask.task.id, selectedTask.task.name);
+                setSelectedId(null);
+              }}
             />
-          ))}
+          )}
         </div>
       </div>
 
-      <div className="task-detail-panel">
-        {selectedTask || isNew ? (
-          <TaskDetailPanel
-            key={isNew ? "__new__" : effectiveId}
-            task={selectedTask?.task}
-            taskStatus={selectedTask}
-            isNew={isNew}
-            onSave={async (task) => {
-              const ok = await onSave(task);
-              if (ok && isNew) {
-                setSelectedId(task.id);
-                setIsNew(false);
-              }
-              return ok;
-            }}
-            onRun={() => effectiveId && onRun(effectiveId)}
-            onStop={() => effectiveId && onStop(effectiveId)}
-            onDelete={() => {
-              if (selectedTask) {
-                onDelete(selectedTask.task.id, selectedTask.task.name);
-                setSelectedId(null);
-              }
-            }}
-          />
-        ) : null}
-      </div>
-    </div>
+      {isNewTask && (
+        <NewTaskModal
+          onSave={onSave}
+          onClose={() => onNewTaskChange(false)}
+        />
+      )}
+    </>
   );
 }

--- a/cli/src/web/hooks.ts
+++ b/cli/src/web/hooks.ts
@@ -1,5 +1,5 @@
 import { useState, useEffect, useCallback, useRef } from "react";
-import type { TaskStatus, ExecutionRecord, TaskDefinition } from "./types.ts";
+import type { TaskStatus, ExecutionRecord, TaskDefinition, GlobalSettings } from "./types.ts";
 import { formatCountdown } from "./format.ts";
 
 export function useTasks() {
@@ -173,5 +173,41 @@ export async function deleteTask(id: string) {
     await apiCall(`/api/tasks/${id}`, { method: "DELETE" });
   } catch (e: unknown) {
     showError(`タスクの削除に失敗: ${errorMessage(e)}`);
+  }
+}
+
+export function useSettings() {
+  const [settings, setSettings] = useState<GlobalSettings | null>(null);
+  const [loading, setLoading] = useState(true);
+
+  const load = useCallback(async () => {
+    try {
+      const res = await fetch("/api/settings");
+      if (!res.ok) throw new Error(`HTTP ${res.status}`);
+      const data = await res.json();
+      setSettings(data.settings ?? {});
+    } catch {
+      // エラー時は既存を維持
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  useEffect(() => { load(); }, [load]);
+
+  return { settings, loading, reload: load };
+}
+
+export async function updateSettings(settings: GlobalSettings): Promise<boolean> {
+  try {
+    await apiCall("/api/settings", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(settings),
+    });
+    return true;
+  } catch (e: unknown) {
+    showError(`設定の保存に失敗: ${errorMessage(e)}`);
+    return false;
   }
 }

--- a/cli/src/web/style.css
+++ b/cli/src/web/style.css
@@ -174,10 +174,21 @@ main {
 }
 
 /* ======== TABS ======== */
+.tabs-toolbar {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  margin-bottom: 20px;
+}
+
+.tabs-toolbar > .btn-primary {
+  padding: 8px 20px;
+  font-size: 14px;
+}
+
 .tabs {
   display: flex;
   gap: 2px;
-  margin-bottom: 20px;
   background: var(--bg-raised);
   border-radius: var(--radius);
   padding: 3px;
@@ -232,13 +243,6 @@ main {
   min-height: 0;
 }
 
-button.new-task-btn {
-  width: 100%;
-  flex-shrink: 0;
-  padding: 12px 12px;
-  font-size: 14px;
-}
-
 .task-list {
   display: flex;
   flex-direction: column;
@@ -290,6 +294,26 @@ button.new-task-btn {
   font-family: var(--font-mono);
   color: var(--text-tertiary);
   margin-top: 1px;
+}
+
+/* --- Directory group --- */
+.task-group {
+  margin-bottom: 4px;
+}
+
+.task-group:last-child {
+  margin-bottom: 0;
+}
+
+.task-group-header {
+  font-size: 11px;
+  font-family: var(--font-mono);
+  color: var(--text-tertiary);
+  padding: 8px 12px 4px;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  opacity: 0.7;
 }
 
 /* --- Detail panel (right) --- */
@@ -1150,6 +1174,26 @@ button.new-task-btn {
   padding: 20px 24px 24px;
 }
 
+.modal-footer {
+  display: flex;
+  justify-content: flex-end;
+  padding: 16px 24px;
+  border-top: 1px solid var(--border-subtle);
+}
+
+.modal.modal-new-task {
+  max-width: 640px;
+  max-height: calc(100vh - 100px);
+  display: flex;
+  flex-direction: column;
+}
+
+.modal.modal-new-task .modal-body {
+  overflow-y: auto;
+  flex: 1;
+  min-height: 0;
+}
+
 /* ======== FORM ======== */
 .form-group {
   margin-bottom: 16px;
@@ -1544,4 +1588,75 @@ button.new-task-btn {
 @keyframes row-in {
   from { opacity: 0; transform: translateY(4px); }
   to { opacity: 1; transform: translateY(0); }
+}
+
+/* ======== SETTINGS ======== */
+.settings-view {
+  max-width: 640px;
+  animation: onboarding-in 0.3s cubic-bezier(0.16, 1, 0.3, 1);
+}
+
+.settings-card {
+  background: var(--bg-raised);
+  border: 1px solid var(--border-subtle);
+  border-radius: var(--radius-lg);
+  overflow: hidden;
+}
+
+.settings-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 16px 24px;
+  border-bottom: 1px solid var(--border-subtle);
+}
+
+.settings-title {
+  font-size: 15px;
+  font-weight: 600;
+}
+
+.settings-section {
+  padding: 20px 24px;
+  border-bottom: 1px solid var(--border-subtle);
+}
+
+.settings-section:last-child {
+  border-bottom: none;
+}
+
+.settings-section-title {
+  font-size: 11px;
+  font-weight: 500;
+  color: var(--text-tertiary);
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  margin-bottom: 16px;
+}
+
+.settings-field {
+  margin-bottom: 16px;
+}
+
+.settings-field:last-child {
+  margin-bottom: 0;
+}
+
+.settings-label {
+  display: block;
+  font-size: 13px;
+  font-weight: 500;
+  color: var(--text-secondary);
+  margin-bottom: 6px;
+}
+
+.settings-field-row {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.settings-timeout-input {
+  width: 100px;
+  text-align: right;
 }

--- a/cli/src/web/types.ts
+++ b/cli/src/web/types.ts
@@ -41,3 +41,8 @@ export interface TaskStatus {
   nextRunAt?: string;
   isRunning: boolean;
 }
+
+export interface GlobalSettings {
+  slack_webhook_url?: string;
+  default_timeout?: number;
+}

--- a/daemon/Sources/Core/IPCProtocol.swift
+++ b/daemon/Sources/Core/IPCProtocol.swift
@@ -120,13 +120,23 @@ public struct IPCNotification: Codable, Sendable {
 /// アプリ全体の設定。
 public struct GlobalSettings: Codable, Sendable, Equatable {
     public var slackWebhookURL: String?
+    public var defaultTimeout: Int?
 
-    public init(slackWebhookURL: String? = nil) {
+    public static let defaultTimeoutValue = 3600
+
+    public init(slackWebhookURL: String? = nil, defaultTimeout: Int? = nil) {
         self.slackWebhookURL = slackWebhookURL
+        self.defaultTimeout = defaultTimeout
+    }
+
+    /// タスク個別のタイムアウトが未設定の場合に使うタイムアウト値を返す。
+    public var effectiveDefaultTimeout: Int {
+        defaultTimeout ?? Self.defaultTimeoutValue
     }
 
     enum CodingKeys: String, CodingKey {
         case slackWebhookURL = "slack_webhook_url"
+        case defaultTimeout = "default_timeout"
     }
 }
 

--- a/daemon/Sources/DaemonLib/TaskExecutor.swift
+++ b/daemon/Sources/DaemonLib/TaskExecutor.swift
@@ -13,7 +13,8 @@ public final class TaskExecutor: @unchecked Sendable {
     public init() {}
 
     /// タスクを実行し、完了した ExecutionRecord を返す。
-    public func execute(_ task: TaskDefinition) -> ExecutionRecord {
+    /// `defaultTimeout` はタスク個別のタイムアウトが未設定の場合のフォールバック。
+    public func execute(_ task: TaskDefinition, defaultTimeout: Int? = nil) -> ExecutionRecord {
         var record = ExecutionRecord(
             taskId: task.id,
             taskName: task.name,
@@ -25,7 +26,9 @@ public final class TaskExecutor: @unchecked Sendable {
 
         let process = Process()
         process.executableURL = URL(fileURLWithPath: "/bin/zsh")
-        process.arguments = ["-l", "-c", task.command]
+        // set -e: 途中のコマンドが失敗したら即終了
+        // set -o pipefail: パイプライン中の失敗も検知
+        process.arguments = ["-l", "-c", "set -eo pipefail\n" + task.command]
 
         let dir = task.workingDirectory ?? "~"
         let expandedDir = NSString(string: dir).expandingTildeInPath
@@ -49,7 +52,8 @@ public final class TaskExecutor: @unchecked Sendable {
             try process.run()
 
             var timedOut = false
-            if let timeout = task.timeout, timeout > 0 {
+            let effectiveTimeout = task.timeout ?? defaultTimeout
+            if let timeout = effectiveTimeout, timeout > 0 {
                 timedOut = waitWithTimeout(process: process, timeout: TimeInterval(timeout))
             } else {
                 process.waitUntilExit()

--- a/daemon/Sources/DaemonLib/TaskScheduler.swift
+++ b/daemon/Sources/DaemonLib/TaskScheduler.swift
@@ -19,6 +19,7 @@ public final class TaskScheduler: @unchecked Sendable {
     private let lock = NSLock()
     private var isDarkWakePaused = false
     private var isShuttingDown = false
+    private var cachedSettings = GlobalSettings()
 
     /// ネットワーク未接続時の保留キュー（タスクID → タスク定義 + プレースホルダーのレコードID）。
     /// 各タスクにつき最大1件保留。復帰時に同じレコードを更新する。
@@ -42,8 +43,9 @@ public final class TaskScheduler: @unchecked Sendable {
         reloadTasks()
         startScheduleTimer()
         startFileWatcher()
-        // 起動時に設定を読み込んで Slack URL をセット
+        // 起動時に設定を読み込んで反映
         let settings = loadSettings()
+        lock.withLock { cachedSettings = settings }
         slackNotifier.webhookURL = settings.slackWebhookURL
 
         // ネットワーク監視を起動
@@ -238,6 +240,7 @@ public final class TaskScheduler: @unchecked Sendable {
     public func saveSettings(_ settings: GlobalSettings) throws {
         let yaml = try YAMLEncoder().encode(settings)
         try yaml.write(to: ConfigPaths.settingsFile, atomically: true, encoding: .utf8)
+        lock.withLock { cachedSettings = settings }
         slackNotifier.webhookURL = settings.slackWebhookURL
     }
 
@@ -329,9 +332,10 @@ public final class TaskScheduler: @unchecked Sendable {
 
     /// タスクを非同期実行し、指定レコードIDで結果を更新する。
     private func runTask(_ task: TaskDefinition, recordId: UUID) {
+        let defaultTimeout = lock.withLock { cachedSettings.effectiveDefaultTimeout }
         DispatchQueue.global(qos: .userInitiated).async { [weak self] in
             guard let self else { return }
-            let result = self.executor.execute(task)
+            let result = self.executor.execute(task, defaultTimeout: defaultTimeout)
             let finalRecord = ExecutionRecord(
                 id: recordId,
                 taskId: result.taskId,

--- a/daemon/Tests/CoreTests/GlobalSettingsTests.swift
+++ b/daemon/Tests/CoreTests/GlobalSettingsTests.swift
@@ -1,0 +1,23 @@
+import Testing
+@testable import Core
+
+@Suite("GlobalSettings.effectiveDefaultTimeout")
+struct GlobalSettingsEffectiveTimeoutTests {
+    @Test("Returns custom value when defaultTimeout is set")
+    func customValue() {
+        let settings = GlobalSettings(defaultTimeout: 60)
+        #expect(settings.effectiveDefaultTimeout == 60)
+    }
+
+    @Test("Falls back to defaultTimeoutValue when defaultTimeout is nil")
+    func fallbackToDefault() {
+        let settings = GlobalSettings()
+        #expect(settings.effectiveDefaultTimeout == GlobalSettings.defaultTimeoutValue)
+        #expect(settings.effectiveDefaultTimeout == 3600)
+    }
+
+    @Test("defaultTimeoutValue is 3600")
+    func staticDefault() {
+        #expect(GlobalSettings.defaultTimeoutValue == 3600)
+    }
+}

--- a/daemon/Tests/DaemonTests/TaskExecutorTests.swift
+++ b/daemon/Tests/DaemonTests/TaskExecutorTests.swift
@@ -60,6 +60,57 @@ struct TaskExecutorTimeoutTests {
         #expect(record.status == .failure)
         #expect(record.exitCode == 1)
     }
+
+    @Test("Multi-line command fails if any line fails (set -e)")
+    func multiLineFailsOnFirstError() {
+        let executor = TaskExecutor()
+        let task = makeTask(command: "exit 1\necho should-not-reach")
+        let record = executor.execute(task)
+        #expect(record.status == .failure)
+        #expect(record.exitCode == 1)
+        #expect(!record.stdout.contains("should-not-reach"))
+    }
+
+    @Test("Multi-line command succeeds only if all lines succeed")
+    func multiLineAllSuccess() {
+        let executor = TaskExecutor()
+        let task = makeTask(command: "echo line1\necho line2")
+        let record = executor.execute(task)
+        #expect(record.status == .success)
+        #expect(record.stdout.contains("line1"))
+        #expect(record.stdout.contains("line2"))
+    }
+
+    @Test("Default timeout is used as fallback when task timeout is nil")
+    func defaultTimeoutFallback() {
+        let executor = TaskExecutor()
+        let task = makeTask(command: "sleep 60")
+        let start = Date()
+        let record = executor.execute(task, defaultTimeout: 1)
+        let elapsed = Date().timeIntervalSince(start)
+        #expect(record.status == .timeout)
+        #expect(elapsed < 10)
+    }
+
+    @Test("Task-specific timeout takes priority over default timeout")
+    func taskTimeoutOverridesDefault() {
+        let executor = TaskExecutor()
+        let task = makeTask(command: "sleep 60", timeout: 1)
+        let start = Date()
+        // defaultTimeout is very long, but task timeout (1s) should win
+        let record = executor.execute(task, defaultTimeout: 300)
+        let elapsed = Date().timeIntervalSince(start)
+        #expect(record.status == .timeout)
+        #expect(elapsed < 10)
+    }
+
+    @Test("Default timeout of 0 means no timeout for tasks without specific timeout")
+    func zeroDefaultTimeoutMeansNoLimit() {
+        let executor = TaskExecutor()
+        let task = makeTask(command: "echo quick")
+        let record = executor.execute(task, defaultTimeout: 0)
+        #expect(record.status == .success)
+    }
 }
 
 @Suite("TaskExecutor - stopAll")


### PR DESCRIPTION
## Issue
https://github.com/gehnmaisoda/local-runner/issues/7

## Summary
- Web UIに設定タブを追加（デフォルトタイムアウト / Slack webhook URL）
- グローバルデフォルトタイムアウト（3600秒）を導入し、タスク個別タイムアウト未設定時にフォールバック適用
- `set -eo pipefail` で複数行コマンドの失敗を即座に検知
- 新規タスク作成をモーダルに分離（既存タスクはauto-save維持）
- タスク一覧を実行ディレクトリでグルーピング表示
- 1Passwordオートフィル抑制

## Diff

### Before
- 設定変更は `~/.config/local-runner/settings.yaml` を手動編集するしかない
- タスク個別タイムアウト未設定時は無制限
- 複数行コマンドで途中の失敗が無視される
- 新規タスク作成がインラインで、auto-save時にフォーカスが外れる問題
- タスク一覧はフラットに表示

### After
```
┌─────────────────────────────────────────┐
│ タスク │ 実行ログ │ 設定 │ [+ 新規タスク] │  ← タブ横にボタン配置
├─────────────┬───────────────────────────┤
│ ~/projects  │                           │
│  ├ task-A   │   タスク詳細 (auto-save)  │
│  └ task-B   │                           │
│ ~/other     │                           │
│  └ task-C   │                           │
├─────────────┴───────────────────────────┤
│           設定ページ                      │
│  デフォルトタイムアウト: [3600] 秒        │
│  Slack Webhook URL: [https://...]       │
└─────────────────────────────────────────┘
```

- 設定ページからデフォルトタイムアウトとSlack URLを編集可能（auto-save）
- 個別タイムアウト > デフォルトタイムアウト(3600秒) の優先順位
- `set -eo pipefail` で複数行コマンドのどれか1つ失敗で即失敗ステータス
- 新規タスク作成はモーダルで「作成」ボタン押下まで保存されない
- タスク一覧は `working_directory` でグルーピング（深いパスは末尾2セグメント表示）

## Test plan
- [x] Swift テスト 125件通過（新規8件: デフォルトタイムアウト, set -e, GlobalSettings）
- [x] TS テスト 13件通過（新規: resolveHome, shortenDir）
- [ ] Web UI: 設定ページでタイムアウト/Webhook URL変更 → auto-save確認
- [ ] Web UI: 新規タスクモーダル → 作成/キャンセル/Escape確認
- [ ] Web UI: タスク一覧のディレクトリグルーピング確認
- [ ] 複数行コマンドで途中失敗 → 失敗ステータスになること確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)