### PR TITLE
v0.1.0 セルフレビュー修正

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,9 @@ cli/lr
 # macOS
 .DS_Store
 
+# Build artifacts
+dist/
+
 # Test results
 test-results/
 

--- a/Makefile
+++ b/Makefile
@@ -47,3 +47,4 @@ install: build
 clean:
 	cd daemon && swift package clean
 	rm -f cli/lr
+	rm -rf dist

--- a/cli/index.ts
+++ b/cli/index.ts
@@ -228,7 +228,7 @@ async function main() {
     console.log(`lr ${CLI_VERSION}`);
     try {
       const client = await createClient();
-      const res = await client.send({ action: "get_version" });
+      const res = await client.send({ action: "get_version" }, 1000);
       if (res.version) {
         console.log(`local-runner-daemon ${res.version}`);
       }

--- a/cli/src/args.test.ts
+++ b/cli/src/args.test.ts
@@ -122,6 +122,16 @@ describe("parseArgs", () => {
     expect(result.options.has("name")).toBe(false);
   });
 
+  test("parses --version flag", () => {
+    const result = parseArgs(["--version"]);
+    expect(result.flags.has("version")).toBe(true);
+  });
+
+  test("parses -V as version", () => {
+    const result = parseArgs(["-V"]);
+    expect(result.flags.has("version")).toBe(true);
+  });
+
   test("does not consume flag as option value", () => {
     // --name is a value-taking option, but if next arg is missing, it's skipped
     const result = parseArgs(["--timeout"]);

--- a/cli/src/launchagent.test.ts
+++ b/cli/src/launchagent.test.ts
@@ -9,22 +9,31 @@ import { homedir } from "os";
 // we test the observable behavior and path logic.
 
 describe("LaunchAgent paths", () => {
-  const LABEL = "com.gehnmaisoda.local-runner.daemon";
-  const PLIST_FILENAME = `${LABEL}.plist`;
+  const LABEL_PROD = "com.gehnmaisoda.local-runner.daemon";
+  const LABEL_DEV = "com.gehnmaisoda.local-runner.daemon.dev";
   const LAUNCH_AGENTS_DIR = join(homedir(), "Library", "LaunchAgents");
-  const PLIST_PATH = join(LAUNCH_AGENTS_DIR, PLIST_FILENAME);
 
-  test("label follows reverse-DNS convention", () => {
-    expect(LABEL).toMatch(/^com\.\w+\.\S+$/);
+  test("prod label follows reverse-DNS convention", () => {
+    expect(LABEL_PROD).toMatch(/^com\.\w+\.\S+$/);
+  });
+
+  test("dev label has .dev suffix", () => {
+    expect(LABEL_DEV).toBe(`${LABEL_PROD}.dev`);
+  });
+
+  test("dev and prod labels are different", () => {
+    expect(LABEL_DEV).not.toBe(LABEL_PROD);
   });
 
   test("plist filename matches label", () => {
-    expect(PLIST_FILENAME).toBe(`${LABEL}.plist`);
+    expect(`${LABEL_PROD}.plist`).toBe("com.gehnmaisoda.local-runner.daemon.plist");
+    expect(`${LABEL_DEV}.plist`).toBe("com.gehnmaisoda.local-runner.daemon.dev.plist");
   });
 
   test("plist path is in ~/Library/LaunchAgents", () => {
-    expect(PLIST_PATH).toBe(
-      join(homedir(), "Library", "LaunchAgents", `${LABEL}.plist`)
+    const plistPath = join(LAUNCH_AGENTS_DIR, `${LABEL_PROD}.plist`);
+    expect(plistPath).toBe(
+      join(homedir(), "Library", "LaunchAgents", `${LABEL_PROD}.plist`)
     );
   });
 

--- a/cli/src/launchagent.ts
+++ b/cli/src/launchagent.ts
@@ -18,25 +18,14 @@ const LOG_DIR = join(
 );
 
 function findDaemonBinary(): string | null {
-  const candidates: string[] = [];
-
-  // 1. Homebrew prefix (brew install local-runner)
-  try {
-    const result = Bun.spawnSync(["brew", "--prefix", "local-runner"]);
-    if (result.exitCode === 0) {
-      const prefix = result.stdout.toString().trim();
-      candidates.push(join(prefix, "bin", "local-runner-daemon"));
-    }
-  } catch { /* brew not available */ }
-
-  // 2. Common Homebrew paths
-  candidates.push("/opt/homebrew/bin/local-runner-daemon");
-  candidates.push("/usr/local/bin/local-runner-daemon");
-
-  // 3. Development builds (relative to project)
+  // Homebrew (arm64 / Intel) → dev builds の優先順で探索
   const projectRoot = resolve(import.meta.dir, "..", "..");
-  candidates.push(join(projectRoot, "daemon", ".build", "release", "local-runner"));
-  candidates.push(join(projectRoot, "daemon", ".build", "debug", "local-runner"));
+  const candidates = [
+    "/opt/homebrew/bin/local-runner-daemon",
+    "/usr/local/bin/local-runner-daemon",
+    join(projectRoot, "daemon", ".build", "release", "local-runner"),
+    join(projectRoot, "daemon", ".build", "debug", "local-runner"),
+  ];
 
   for (const p of candidates) {
     try {

--- a/daemon/Sources/Core/IPCProtocol.swift
+++ b/daemon/Sources/Core/IPCProtocol.swift
@@ -39,6 +39,7 @@ public struct IPCRequest: Codable, Sendable {
     public static func saveTask(_ t: TaskDefinition) -> Self { .init(action: "save_task", task: t) }
     public static func deleteTask(_ id: String) -> Self { .init(action: "delete_task", taskId: id) }
     public static func toggleTask(_ id: String) -> Self { .init(action: "toggle_task", taskId: id) }
+    public static var getVersion: Self { .init(action: "get_version") }
     public static var subscribe: Self { .init(action: "subscribe") }
 }
 

--- a/daemon/Tests/DaemonTests/IPCServerTests.swift
+++ b/daemon/Tests/DaemonTests/IPCServerTests.swift
@@ -79,6 +79,18 @@ struct IPCServerWireFormatTests {
         #expect(decoded.tasks?[0].task.id == "t1")
     }
 
+    @Test("IPCResponse with version encodes and decodes correctly")
+    func encodeVersionResponse() throws {
+        let response = IPCResponse(version: "0.1.0")
+        let data = try IPCWireFormat.encode(response)
+        var buffer = data
+        let json = IPCWireFormat.readMessage(from: &buffer)!
+        let decoded = try IPCWireFormat.decode(IPCResponse.self, from: json)
+        #expect(decoded.success == true)
+        #expect(decoded.version == "0.1.0")
+        #expect(decoded.tasks == nil)
+    }
+
     @Test("IPCResponse with history includes execution records")
     func encodeHistoryResponse() throws {
         let record = ExecutionRecord(taskId: "t1", taskName: "Test", status: .success)
@@ -217,6 +229,13 @@ struct IPCRequestFactoryTests {
         let req = IPCRequest.toggleTask("toggle-me")
         #expect(req.action == "toggle_task")
         #expect(req.taskId == "toggle-me")
+    }
+
+    @Test("getVersion creates correct action")
+    func getVersion() {
+        let req = IPCRequest.getVersion
+        #expect(req.action == "get_version")
+        #expect(req.taskId == nil)
     }
 
     @Test("subscribe creates correct action")


### PR DESCRIPTION
## Issue
https://github.com/gehnmaisoda/local-runner/issues/17

## Summary
main に直接マージした v0.1.0 リリース準備コミットのセルフレビュー指摘を修正。テスト追加・不要な処理の除去・UX 改善。

## Diff

### テスト追加
| Before | After |
|---|---|
| `get_version` IPC アクションのテストなし | レスポンスのラウンドトリップ + ファクトリメソッドのテスト追加 |
| `--version` / `-V` フラグのパーステストなし | 2件追加 |
| LaunchAgent テストが prod Label をハードコード | dev/prod 隔離を反映したテストに更新 |

### 簡素化
| Before | After |
|---|---|
| `findDaemonBinary()` が `Bun.spawnSync(["brew", "--prefix", ...])` を実行（100ms〜1s のブロッキング呼び出し） | 削除。ハードコードパス (`/opt/homebrew/bin/`, `/usr/local/bin/`) で十分カバー |
| `--version` の daemon 接続タイムアウト 5秒 | 1秒に短縮（バージョン確認にユーザーを待たせない） |

### その他
- `dist/` を `.gitignore` に追加
- `make clean` で `dist/` を削除
- `IPCRequest.getVersion` ファクトリメソッド追加（他アクションとの一貫性）