### PR TITLE
fix: キャッチアップ重複実行防止 & システムログ機能追加

### DIFF
--- a/.claude/skills/lr/SKILL.md
+++ b/.claude/skills/lr/SKILL.md
@@ -15,6 +15,8 @@ argument-hint: "[操作内容を自然言語で]"
 - **全コマンドに `--json` を付けること**。出力を正確にパースするために必須。
 - 削除時は **`--yes`** を必ず付けて確認プロンプトをスキップする。
 - コマンドの実行結果は JSON で返る。成功時は各コマンド固有の形式、エラー時は `{"success":false,"error":"..."}` 形式。
+- **`--timeout` は付けない**。ユーザーが明示的に指定した場合のみ付ける。
+- **スケジュールの組み方が不明な場合は必ず AskUserQuestion で確認する**。推測で作成しない。
 - ユーザーに結果を伝える際は JSON をそのまま見せず、**人間が読みやすい形に整形**して説明する。
 
 ## コマンド一覧
@@ -119,6 +121,16 @@ lr config get --json
 # 設定変更
 lr config set default_timeout 1800 --json
 lr config set slack_webhook_url "https://hooks.slack.com/..." --json
+```
+
+### システムログ
+
+```bash
+# デーモンのシステムログを表示
+lr syslog --json
+
+# システムログを削除
+lr syslog --clear --json
 ```
 
 ### その他

--- a/cli/index.ts
+++ b/cli/index.ts
@@ -4,7 +4,7 @@ import { parseArgs } from "./src/args.ts";
 import {
   listTasks, showTask, createTask, editTask, deleteTask,
   runTask, stopTask, toggleTask, showLogs, showStatus,
-  configGet, configSet, reloadTasks,
+  configGet, configSet, syslog, reloadTasks,
   CLIError, EXIT, parsePositiveInt,
 } from "./src/commands.ts";
 import { startServer } from "./src/serve.ts";
@@ -42,6 +42,7 @@ const MAIN_HELP = `使い方: lr [コマンド] [オプション]
   status              サマリーを表示
   config get          設定を表示
   config set <k> <v>  設定を変更
+  syslog              デーモンのシステムログを表示
   reload              タスク定義を再読み込み
   serve [ポート]      Web UI をブラウザを開かずに起動
   install             デーモンを LaunchAgent として登録
@@ -190,6 +191,14 @@ const HELP: Record<string, string> = {
   lr config get
   lr config set default_timeout 1800
   lr config set slack_webhook_url "https://hooks.slack.com/services/..."`,
+
+  syslog: `デーモンのシステムログを表示します。
+
+使い方: lr syslog [オプション]
+
+オプション:
+  --clear   ログを削除
+  --json    JSON で出力`,
 
   reload: `タスク定義ファイルを再読み込みします。
 
@@ -343,6 +352,10 @@ async function main() {
       }
       break;
     }
+
+    case "syslog":
+      await syslog(json, args.flags.has("clear"));
+      break;
 
     case "reload":
       await reloadTasks(json);

--- a/cli/src/commands.test.ts
+++ b/cli/src/commands.test.ts
@@ -1,6 +1,6 @@
 import { describe, test, expect } from "bun:test";
 import {
-  formatDate, formatDuration, statusIcon, pad,
+  formatDate, formatDuration, formatTimestamp, statusIcon, pad,
   formatSchedule, generateId, buildSchedule, applyScheduleEdits,
   statusLabel, parsePositiveInt,
   CLIError, EXIT,
@@ -322,6 +322,24 @@ describe("applyScheduleEdits", () => {
     const existing = { type: "daily", time: "09:00" };
     const result = applyScheduleEdits(existing, new Map());
     expect(result).toEqual(existing);
+  });
+});
+
+// --- formatTimestamp tests ---
+
+describe("formatTimestamp", () => {
+  test("formats ISO date to YYYY-MM-DD HH:mm:ss", () => {
+    // Use a fixed UTC date and check the local representation
+    const result = formatTimestamp("2026-01-05T00:09:03Z");
+    // Should contain the date part with zero-padded values
+    expect(result).toMatch(/^\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}$/);
+  });
+
+  test("zero-pads single digit month and day", () => {
+    // Use a Date known in local timezone to verify zero-padding
+    const d = new Date(2026, 0, 5, 3, 7, 9); // Jan 5, 03:07:09 local
+    const result = formatTimestamp(d.toISOString());
+    expect(result).toBe("2026-01-05 03:07:09");
   });
 });
 

--- a/cli/src/commands.ts
+++ b/cli/src/commands.ts
@@ -1,4 +1,4 @@
-import { createClient, type IPCClient, type TaskStatus, type ExecutionRecord, type Schedule, type TaskDefinition, type GlobalSettings } from "./ipc.ts";
+import { createClient, type IPCClient, type TaskStatus, type ExecutionRecord, type Schedule, type TaskDefinition, type GlobalSettings, type LogEntry } from "./ipc.ts";
 import { createInterface } from "readline";
 
 // --- Exit codes ---
@@ -29,6 +29,13 @@ export function formatDate(iso: string | undefined): string {
     minute: "2-digit",
     second: "2-digit",
   });
+}
+
+/** ISO 日付文字列を "YYYY-MM-DD HH:mm:ss" 形式に変換する。 */
+export function formatTimestamp(iso: string): string {
+  const d = new Date(iso);
+  const p = (n: number) => String(n).padStart(2, "0");
+  return `${d.getFullYear()}-${p(d.getMonth() + 1)}-${p(d.getDate())} ${p(d.getHours())}:${p(d.getMinutes())}:${p(d.getSeconds())}`;
 }
 
 export function formatDuration(record: ExecutionRecord): string {
@@ -642,6 +649,43 @@ export async function configSet(key: string, value: string, json: boolean) {
       console.log(JSON.stringify({ success: true }));
     } else {
       console.log(`${key} を ${value} に設定しました。`);
+    }
+  });
+}
+
+export async function syslog(json: boolean, clear: boolean) {
+  await withClient(async (client) => {
+    if (clear) {
+      const res = await client.send({ action: "clear_system_logs" });
+      if (!res.success) {
+        throw new CLIError(res.error ?? "システムログの削除に失敗しました", EXIT.GENERAL);
+      }
+      if (json) {
+        console.log(JSON.stringify({ success: true }));
+      } else {
+        console.log("システムログを削除しました。");
+      }
+      return;
+    }
+
+    const res = await client.send({ action: "get_system_logs", limit: 1000 });
+    if (!res.success) {
+      throw new CLIError(res.error ?? "システムログの取得に失敗しました", EXIT.GENERAL);
+    }
+
+    const logs: LogEntry[] = res.systemLogs ?? [];
+    if (json) {
+      console.log(JSON.stringify({ success: true, systemLogs: logs }));
+      return;
+    }
+
+    if (logs.length === 0) {
+      console.log("ログがありません。");
+      return;
+    }
+
+    for (const entry of logs) {
+      console.log(`${formatTimestamp(entry.timestamp)}  ${entry.tag.padEnd(12)}  ${entry.message}`);
     }
   });
 }

--- a/cli/src/ipc.test.ts
+++ b/cli/src/ipc.test.ts
@@ -119,6 +119,67 @@ test("send() rejects immediately when not connected", async () => {
   ).rejects.toThrow("接続されていません");
 });
 
+test("send() receives systemLogs in response", async () => {
+  const sockPath = testSocketPath();
+  cleanupPaths.push(sockPath);
+
+  const mockLogs = [
+    { timestamp: "2026-04-06T09:00:00+09:00", tag: "Scheduler", message: "test msg" },
+  ];
+
+  const server = Bun.listen({
+    unix: sockPath,
+    socket: {
+      data(socket) {
+        socket.write(encodeResponse({ success: true, systemLogs: mockLogs }));
+      },
+      open() {},
+      close() {},
+    },
+  });
+  cleanupServers.push(server);
+
+  const client = new IPCClient();
+  await client.connect(sockPath);
+
+  try {
+    const res = await client.send({ action: "get_system_logs", limit: 1000 }, 1000);
+    expect(res.success).toBe(true);
+    expect(res.systemLogs).toHaveLength(1);
+    expect(res.systemLogs![0].tag).toBe("Scheduler");
+    expect(res.systemLogs![0].message).toBe("test msg");
+  } finally {
+    client.close();
+  }
+});
+
+test("send() clear_system_logs returns success", async () => {
+  const sockPath = testSocketPath();
+  cleanupPaths.push(sockPath);
+
+  const server = Bun.listen({
+    unix: sockPath,
+    socket: {
+      data(socket) {
+        socket.write(encodeResponse({ success: true }));
+      },
+      open() {},
+      close() {},
+    },
+  });
+  cleanupServers.push(server);
+
+  const client = new IPCClient();
+  await client.connect(sockPath);
+
+  try {
+    const res = await client.send({ action: "clear_system_logs" }, 1000);
+    expect(res.success).toBe(true);
+  } finally {
+    client.close();
+  }
+});
+
 test("connect() rejects when socket path does not exist", async () => {
   const client = new IPCClient();
 

--- a/cli/src/ipc.ts
+++ b/cli/src/ipc.ts
@@ -59,6 +59,12 @@ export interface IPCRequest {
   settings?: GlobalSettings;
 }
 
+export interface LogEntry {
+  timestamp: string;
+  tag: string;
+  message: string;
+}
+
 export interface IPCResponse {
   success: boolean;
   error?: string;
@@ -66,6 +72,7 @@ export interface IPCResponse {
   history?: ExecutionRecord[];
   settings?: GlobalSettings;
   version?: string;
+  systemLogs?: LogEntry[];
 }
 
 export interface IPCNotification {

--- a/cli/src/serve.ts
+++ b/cli/src/serve.ts
@@ -134,6 +134,17 @@ async function handleAPI(req: Request): Promise<Response> {
       return Response.json(res);
     }
 
+    if (path === "/api/system-logs" && req.method === "GET") {
+      const limit = parseInt(url.searchParams.get("limit") ?? "1000", 10);
+      const res = await sendToIPC({ action: "get_system_logs", limit });
+      return Response.json(res);
+    }
+
+    if (path === "/api/system-logs" && req.method === "DELETE") {
+      const res = await sendToIPC({ action: "clear_system_logs" });
+      return Response.json(res);
+    }
+
     if (path === "/api/settings" && req.method === "GET") {
       const res = await sendToIPC({ action: "get_settings" });
       return Response.json(res);

--- a/cli/src/web/SettingsView.tsx
+++ b/cli/src/web/SettingsView.tsx
@@ -1,5 +1,5 @@
 import React, { useState, useEffect, useRef } from "react";
-import type { GlobalSettings } from "./types.ts";
+import type { GlobalSettings, LogEntry } from "./types.ts";
 
 interface Props {
   settings: GlobalSettings | null;
@@ -14,6 +14,7 @@ export function SettingsView({ settings, loading, onSave }: Props) {
   const [webhookURL, setWebhookURL] = useState("");
   const [defaultTimeout, setDefaultTimeout] = useState(DEFAULT_TIMEOUT);
   const [saveStatus, setSaveStatus] = useState<"idle" | "saving" | "saved">("idle");
+  const [showSystemLog, setShowSystemLog] = useState(false);
 
   const initialized = useRef(false);
 
@@ -98,6 +99,98 @@ export function SettingsView({ settings, loading, onSave }: Props) {
               タスクの「失敗時に通知」が有効な場合、失敗・タイムアウト時にこの Webhook に通知が送信されます。
             </div>
           </div>
+        </div>
+
+        <div className="settings-section">
+          <h3 className="settings-section-title">デバッグ</h3>
+          <div className="settings-field">
+            <button className="btn-small" onClick={() => setShowSystemLog(true)}>
+              システムログを表示
+            </button>
+          </div>
+        </div>
+      </div>
+      {showSystemLog && <SystemLogModal onClose={() => setShowSystemLog(false)} />}
+    </div>
+  );
+}
+
+// --- System Log Modal ---
+
+function SystemLogModal({ onClose }: { onClose: () => void }) {
+  const [logs, setLogs] = useState<LogEntry[]>([]);
+  const [loading, setLoading] = useState(false);
+  const bottomRef = useRef<HTMLDivElement>(null);
+
+  const fetchLogs = async () => {
+    setLoading(true);
+    try {
+      const res = await fetch("/api/system-logs?limit=1000");
+      const data = await res.json();
+      if (data.systemLogs) setLogs(data.systemLogs);
+    } catch { /* ignore */ }
+    setLoading(false);
+  };
+
+  const clearLogs = async () => {
+    if (!confirm("システムログを削除しますか？")) return;
+    try {
+      await fetch("/api/system-logs", { method: "DELETE" });
+      setLogs([]);
+    } catch { /* ignore */ }
+  };
+
+  useEffect(() => { fetchLogs(); }, []);
+
+  useEffect(() => {
+    bottomRef.current?.scrollIntoView({ behavior: "smooth" });
+  }, [logs]);
+
+  useEffect(() => {
+    const onKey = (e: KeyboardEvent) => { if (e.key === "Escape") onClose(); };
+    window.addEventListener("keydown", onKey);
+    const prev = document.body.style.overflow;
+    document.body.style.overflow = "hidden";
+    return () => {
+      window.removeEventListener("keydown", onKey);
+      document.body.style.overflow = prev;
+    };
+  }, [onClose]);
+
+  const formatTimestamp = (ts: string) => {
+    const d = new Date(ts);
+    const pad = (n: number) => String(n).padStart(2, "0");
+    return `${d.getFullYear()}-${pad(d.getMonth() + 1)}-${pad(d.getDate())} ${pad(d.getHours())}:${pad(d.getMinutes())}:${pad(d.getSeconds())}`;
+  };
+
+  return (
+    <div className="modal-overlay" onClick={(e) => { if (e.target === e.currentTarget) onClose(); }}>
+      <div className="modal modal-system-log">
+        <div className="modal-header">
+          <h2>システムログ</h2>
+          <div className="system-log-modal-actions">
+            <button className="btn-small btn-danger" onClick={clearLogs} disabled={logs.length === 0}>
+              削除
+            </button>
+            <button className="btn-small" onClick={fetchLogs} disabled={loading}>
+              {loading ? "..." : "更新"}
+            </button>
+            <button className="modal-close" onClick={onClose}>&times;</button>
+          </div>
+        </div>
+        <div className="system-log-container">
+          {logs.length === 0 ? (
+            <div className="system-log-empty">ログがありません</div>
+          ) : (
+            logs.map((entry, i) => (
+              <div className="system-log-line" key={i}>
+                <span className="system-log-time">{formatTimestamp(entry.timestamp)}</span>
+                <span className={`system-log-tag system-log-tag-${entry.tag.toLowerCase()}`}>{entry.tag}</span>
+                <span className="system-log-message">{entry.message}</span>
+              </div>
+            ))
+          )}
+          <div ref={bottomRef} />
         </div>
       </div>
     </div>

--- a/cli/src/web/style.css
+++ b/cli/src/web/style.css
@@ -1660,3 +1660,83 @@ main {
   width: 100px;
   text-align: right;
 }
+
+/* System Log Modal */
+
+.modal-system-log {
+  width: 800px;
+  max-width: 90vw;
+  max-height: 80vh;
+  display: flex;
+  flex-direction: column;
+}
+
+.modal-system-log .modal-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+}
+
+.system-log-modal-actions {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+}
+
+.btn-small {
+  padding: 3px 10px;
+  font-size: 12px;
+  background: var(--surface);
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  color: var(--text);
+  cursor: pointer;
+  transition: background 0.15s;
+}
+.btn-small:hover { background: var(--hover); }
+.btn-small:disabled { opacity: 0.5; cursor: default; }
+.btn-small.btn-danger { color: var(--red); }
+.btn-small.btn-danger:hover { background: rgba(239, 123, 108, 0.1); }
+
+.system-log-container {
+  flex: 1;
+  overflow-y: auto;
+  padding: 10px 14px;
+  font-family: "SF Mono", "Menlo", monospace;
+  font-size: 11.5px;
+  line-height: 1.6;
+}
+
+.system-log-empty {
+  color: var(--muted);
+  text-align: center;
+  padding: 24px 0;
+}
+
+.system-log-line {
+  display: flex;
+  gap: 8px;
+  padding: 1px 0;
+  align-items: baseline;
+}
+
+.system-log-time {
+  color: var(--muted);
+  flex-shrink: 0;
+}
+
+.system-log-tag {
+  color: var(--accent);
+  flex-shrink: 0;
+  min-width: 70px;
+}
+
+.system-log-tag-wake { color: var(--yellow, #e5c07b); }
+.system-log-tag-scheduler { color: var(--green); }
+.system-log-tag-ipc { color: var(--muted); }
+.system-log-tag-network { color: var(--blue, #61afef); }
+
+.system-log-message {
+  color: var(--text);
+  word-break: break-all;
+}

--- a/cli/src/web/types.ts
+++ b/cli/src/web/types.ts
@@ -46,3 +46,9 @@ export interface GlobalSettings {
   slack_webhook_url?: string;
   default_timeout?: number;
 }
+
+export interface LogEntry {
+  timestamp: string;
+  tag: string;
+  message: string;
+}

--- a/daemon/Sources/Core/IPCProtocol.swift
+++ b/daemon/Sources/Core/IPCProtocol.swift
@@ -41,6 +41,22 @@ public struct IPCRequest: Codable, Sendable {
     public static func toggleTask(_ id: String) -> Self { .init(action: "toggle_task", taskId: id) }
     public static var getVersion: Self { .init(action: "get_version") }
     public static var subscribe: Self { .init(action: "subscribe") }
+    public static func getSystemLogs(limit: Int = 1000) -> Self { .init(action: "get_system_logs", limit: limit) }
+}
+
+// MARK: - System Log Entry
+
+/// システムログのエントリ。
+public struct LogEntry: Codable, Sendable {
+    public let timestamp: Date
+    public let tag: String
+    public let message: String
+
+    public init(timestamp: Date, tag: String, message: String) {
+        self.timestamp = timestamp
+        self.tag = tag
+        self.message = message
+    }
 }
 
 // MARK: - IPC Response
@@ -53,6 +69,7 @@ public struct IPCResponse: Codable, Sendable {
     public var history: [ExecutionRecord]?
     public var settings: GlobalSettings?
     public var version: String?
+    public var systemLogs: [LogEntry]?
 
     public init(
         success: Bool = true,
@@ -60,7 +77,8 @@ public struct IPCResponse: Codable, Sendable {
         tasks: [TaskStatus]? = nil,
         history: [ExecutionRecord]? = nil,
         settings: GlobalSettings? = nil,
-        version: String? = nil
+        version: String? = nil,
+        systemLogs: [LogEntry]? = nil
     ) {
         self.success = success
         self.error = error
@@ -68,6 +86,7 @@ public struct IPCResponse: Codable, Sendable {
         self.history = history
         self.settings = settings
         self.version = version
+        self.systemLogs = systemLogs
     }
 
     public static var ok: Self { .init() }

--- a/daemon/Sources/DaemonLib/IPCServer.swift
+++ b/daemon/Sources/DaemonLib/IPCServer.swift
@@ -313,6 +313,15 @@ public final class IPCServer: @unchecked Sendable {
         case "get_version":
             return IPCResponse(version: AppVersion.current)
 
+        case "get_system_logs":
+            let limit = request.limit ?? 1000
+            let entries = Log.entries(limit: limit)
+            return IPCResponse(systemLogs: entries)
+
+        case "clear_system_logs":
+            Log.clear()
+            return .ok
+
         case "subscribe":
             lock.lock()
             subscriberFDs.append(clientFD)

--- a/daemon/Sources/DaemonLib/Log.swift
+++ b/daemon/Sources/DaemonLib/Log.swift
@@ -1,4 +1,5 @@
 import Foundation
+import Core
 
 /// システムタイムゾーンの ISO 8601 タイムスタンプ付きログ出力。
 public enum Log {
@@ -8,8 +9,36 @@ public enum Log {
         return f
     }()
 
+    private static let bufferLock = NSLock()
+    nonisolated(unsafe) private static var buffer: [LogEntry] = []
+    private static let maxEntries = 1000
+
     public static func info(_ tag: String, _ message: String) {
-        print("[\(formatter.string(from: Date()))] [\(tag)] \(message)")
+        let now = Date()
+        print("[\(formatter.string(from: now))] [\(tag)] \(message)")
+
+        let entry = LogEntry(timestamp: now, tag: tag, message: message)
+        bufferLock.lock()
+        buffer.append(entry)
+        if buffer.count > maxEntries {
+            buffer.removeFirst(buffer.count - maxEntries)
+        }
+        bufferLock.unlock()
+    }
+
+    /// バッファ内のログエントリを返す。
+    public static func entries(limit: Int = 1000) -> [LogEntry] {
+        bufferLock.lock()
+        let result = Array(buffer.suffix(limit))
+        bufferLock.unlock()
+        return result
+    }
+
+    /// バッファをクリアする。
+    public static func clear() {
+        bufferLock.lock()
+        buffer.removeAll()
+        bufferLock.unlock()
     }
 
     /// Date を ISO 8601 形式 (例: 2026-03-30T17:09:03+09:00) で返す。

--- a/daemon/Sources/DaemonLib/TaskScheduler.swift
+++ b/daemon/Sources/DaemonLib/TaskScheduler.swift
@@ -157,10 +157,19 @@ public final class TaskScheduler: @unchecked Sendable {
         let tasksSnapshot = lock.withLock { tasks }
         Log.info("Scheduler", "スリープ復帰を検知。\(Log.formatDate(lastSleepDate)) 以降の未実行タスクを確認中...")
 
+        let now = Date()
         let catchUpTasks = tasksSnapshot.filter { task in
             guard task.enabled, task.catchUp else { return false }
             guard let nextFire = task.schedule.nextFireDate(after: lastSleepDate) else { return false }
-            return nextFire < Date()
+            guard nextFire < now else { return false }
+
+            // スリープ期間中に既に実行済みならスキップ
+            if let lastRun = logStore.lastRecord(taskId: task.id),
+               lastRun.startedAt >= lastSleepDate {
+                Log.info("Scheduler", "キャッチアップ棄却: \(task.name) はスリープ期間中に実行済み (\(Log.formatDate(lastRun.startedAt)))")
+                return false
+            }
+            return true
         }
 
         if networkMonitor.isConnected {

--- a/daemon/Tests/DaemonTests/LogBufferTests.swift
+++ b/daemon/Tests/DaemonTests/LogBufferTests.swift
@@ -1,0 +1,57 @@
+import Testing
+import Foundation
+@testable import Core
+@testable import DaemonLib
+
+@Suite("Log ring buffer", .serialized)
+struct LogBufferTests {
+    init() {
+        Log.clear()
+    }
+
+    @Test("info() stores entries in buffer")
+    func storesEntries() {
+        Log.info("Test", "message 1")
+        Log.info("Test", "message 2")
+
+        let entries = Log.entries()
+        #expect(entries.count == 2)
+        #expect(entries[0].tag == "Test")
+        #expect(entries[0].message == "message 1")
+        #expect(entries[1].message == "message 2")
+    }
+
+    @Test("entries(limit:) returns only the last N entries")
+    func entriesLimit() {
+        for i in 0..<10 {
+            Log.info("T", "msg \(i)")
+        }
+
+        let entries = Log.entries(limit: 3)
+        #expect(entries.count == 3)
+        #expect(entries[0].message == "msg 7")
+        #expect(entries[2].message == "msg 9")
+    }
+
+    @Test("clear() empties the buffer")
+    func clearBuffer() {
+        Log.info("T", "hello")
+        #expect(Log.entries().count == 1)
+
+        Log.clear()
+        #expect(Log.entries().count == 0)
+    }
+
+    @Test("LogEntry fields are populated correctly")
+    func entryFields() {
+        let before = Date()
+        Log.info("Wake", "test message")
+        let after = Date()
+
+        let entry = Log.entries().last!
+        #expect(entry.tag == "Wake")
+        #expect(entry.message == "test message")
+        #expect(entry.timestamp >= before)
+        #expect(entry.timestamp <= after)
+    }
+}

--- a/daemon/Tests/DaemonTests/SchedulerTests.swift
+++ b/daemon/Tests/DaemonTests/SchedulerTests.swift
@@ -110,6 +110,114 @@ struct LogStoreCleanupTests {
     }
 }
 
+// MARK: - Catch-up deduplication tests
+
+@Suite("handleWake catch-up deduplication")
+struct HandleWakeCatchUpTests {
+    @Test("Skips catch-up when task already ran during sleep period")
+    func skipAlreadyRan() throws {
+        setupDirs()
+        defer { cleanupDirs() }
+
+        let taskStore = TaskStore(directory: testTasksDir)
+        let logStore = LogStore(directory: testLogsDir)
+        let scheduler = TaskScheduler(taskStore: taskStore, logStore: logStore)
+        scheduler.displayWakeState = AlwaysAwakeDisplay()
+        let net = MockNetworkMonitor()
+        scheduler.networkMonitor = net
+
+        // Create a task scheduled every_minute with catch_up enabled
+        let task = TaskDefinition(
+            id: "t1", name: "t1", command: "echo hi",
+            schedule: Schedule(type: .everyMinute),
+            enabled: true, catchUp: true
+        )
+        try taskStore.save(task)
+        scheduler.reloadTasks()
+
+        // Simulate: task ran at sleepDate + 1 minute
+        let sleepDate = Date().addingTimeInterval(-3600) // 1 hour ago
+        let ranAt = sleepDate.addingTimeInterval(60)
+        let record = ExecutionRecord(
+            taskId: "t1", taskName: "t1",
+            startedAt: ranAt, finishedAt: ranAt.addingTimeInterval(1),
+            status: .success
+        )
+        logStore.append(record)
+
+        // handleWake should skip t1 because it already ran during sleep
+        Log.clear()
+        scheduler.handleWake(lastSleepDate: sleepDate)
+
+        let logs = Log.entries()
+        let rejected = logs.contains { $0.message.contains("キャッチアップ棄却") && $0.message.contains("t1") }
+        #expect(rejected, "Should log catch-up rejection for already-run task")
+    }
+
+    @Test("Skips catch-up when task has catchUp disabled")
+    func skipCatchUpDisabled() throws {
+        setupDirs()
+        defer { cleanupDirs() }
+
+        let taskStore = TaskStore(directory: testTasksDir)
+        let logStore = LogStore(directory: testLogsDir)
+        let scheduler = TaskScheduler(taskStore: taskStore, logStore: logStore)
+        scheduler.displayWakeState = AlwaysAwakeDisplay()
+        let net = MockNetworkMonitor()
+        scheduler.networkMonitor = net
+
+        let task = TaskDefinition(
+            id: "t3", name: "t3", command: "echo hi",
+            schedule: Schedule(type: .everyMinute),
+            enabled: true, catchUp: false
+        )
+        try taskStore.save(task)
+        scheduler.reloadTasks()
+
+        let sleepDate = Date().addingTimeInterval(-3600)
+        Log.clear()
+        scheduler.handleWake(lastSleepDate: sleepDate)
+
+        let logs = Log.entries()
+        let anyT3 = logs.contains { $0.message.contains("t3") }
+        #expect(!anyT3, "Task with catchUp=false should not appear in catch-up logs")
+    }
+
+    @Test("Executes catch-up when task did not run during sleep period")
+    func executeWhenNotRan() async throws {
+        setupDirs()
+        defer { cleanupDirs() }
+
+        let taskStore = TaskStore(directory: testTasksDir)
+        let logStore = LogStore(directory: testLogsDir)
+        let scheduler = TaskScheduler(taskStore: taskStore, logStore: logStore)
+        scheduler.displayWakeState = AlwaysAwakeDisplay()
+        let net = MockNetworkMonitor()
+        scheduler.networkMonitor = net
+
+        let task = TaskDefinition(
+            id: "t2", name: "t2", command: "echo hi",
+            schedule: Schedule(type: .everyMinute),
+            enabled: true, catchUp: true
+        )
+        try taskStore.save(task)
+        scheduler.reloadTasks()
+
+        // No execution records — task never ran
+        let sleepDate = Date().addingTimeInterval(-3600)
+        Log.clear()
+        scheduler.handleWake(lastSleepDate: sleepDate)
+
+        let logs = Log.entries()
+        let executed = logs.contains { $0.message.contains("キャッチアップ実行") && $0.message.contains("t2") }
+        #expect(executed, "Should execute catch-up for task that didn't run")
+
+        // Wait for async execution to complete
+        try? await Task.sleep(for: .milliseconds(500))
+        scheduler.shutdown()
+    }
+}
+
 // MARK: - NetworkMonitor callback tests
 
 @Suite("NetworkMonitor callback logic")


### PR DESCRIPTION
## Summary
- スリープ復帰時のキャッチアップ実行で、スリープ期間中に既に実行済みのタスクをスキップするよう修正（重複実行防止）
- デーモンのシステムログをリングバッファ（最大1000件）で保持し、Web UI モーダルおよび CLI (`lr syslog`) から確認・削除可能に
- スキルファイルに `--timeout` の非付与ルール、スケジュール不明時の確認ルール、`lr syslog` コマンドを追記

## Diff

### キャッチアップ重複実行防止

```
Before: handleWake() → 全 catchUp タスクを無条件実行 → 重複実行
After:  handleWake() → logStore.lastRecord() で実行済みチェック → スキップ＋ログ
```

### システムログ機能

```
Before: Log.info() → stdout のみ（揮発）
After:  Log.info() → stdout + リングバッファ(1000件) → IPC/API/CLI/Web UI で参照可能
```

```
新規 IPC アクション:
  get_system_logs   → Log.entries(limit)
  clear_system_logs → Log.clear()

新規 CLI コマンド:
  lr syslog          → ログ表示
  lr syslog --clear  → ログ削除

新規 Web UI:
  設定タブ → 「システムログを表示」ボタン → モーダル（更新/削除）
```

## Test plan
- [x] Swift 275 tests passed（新規: Log buffer 4件, catchUp dedup 3件）
- [x] CLI 172 tests passed（新規: IPC systemLogs 2件, formatTimestamp 2件）
- [x] デーモン再起動後、Web UI モーダルでログ表示・削除を確認済み
- [ ] スリープ→復帰で重複実行が発生しないことを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)