### PR TITLE
feat: タスクIDと実行IDをUI上でコピー可能にする

### DIFF
--- a/cli/src/web/LogViewer.tsx
+++ b/cli/src/web/LogViewer.tsx
@@ -1,7 +1,7 @@
 import React, { useEffect, useState } from "react";
 import type { ExecutionRecord } from "./types.ts";
 import { formatDate, formatDuration, statusLabel } from "./format.ts";
-import { TriggerTag } from "./TasksView.tsx";
+import { TriggerTag, CopyableId } from "./TasksView.tsx";
 
 interface ModalProps {
   record: ExecutionRecord;
@@ -54,6 +54,10 @@ export function LogModal({ record, onClose }: ModalProps) {
               <TriggerTag trigger={record.trigger} />
             </div>
             <div className="log-context">
+              <div className="log-context-row">
+                <span className="log-context-label">実行ID</span>
+                <CopyableId value={record.id} />
+              </div>
               {record.command && (
                 <div className="log-context-row">
                   <span className="log-context-label">コマンド</span>

--- a/cli/src/web/TasksView.tsx
+++ b/cli/src/web/TasksView.tsx
@@ -18,6 +18,23 @@ interface Props {
   slackConfigured: boolean;
 }
 
+// --- Copyable ID ---
+
+export function CopyableId({ value }: { value: string }) {
+  const [copied, setCopied] = useState(false);
+  const handleCopy = async () => {
+    await navigator.clipboard.writeText(value);
+    setCopied(true);
+    setTimeout(() => setCopied(false), 1500);
+  };
+  return (
+    <code className="copyable-id" onClick={handleCopy} title="クリックでコピー">
+      {value}
+      <span className="copy-icon">{copied ? "\u2713" : "\u29C9"}</span>
+    </code>
+  );
+}
+
 // --- Shared components ---
 
 function StatusDot({ task }: { task: TaskStatus }) {
@@ -758,6 +775,10 @@ function TaskDetailPanel({ task, taskStatus, onSave, onRun, onStop, onDelete, sl
 
       <div className="detail-body two-col">
         <div className="detail-col-form">
+          <div className="detail-section">
+            <label className="detail-label">タスクID</label>
+            <CopyableId value={task.id} />
+          </div>
           <TaskFormFields form={form} slackConfigured={slackConfigured} />
           <div className="detail-section detail-delete">
             <button className="btn btn-danger-ghost" onClick={onDelete}>

--- a/cli/src/web/TasksView.tsx
+++ b/cli/src/web/TasksView.tsx
@@ -28,10 +28,21 @@ export function CopyableId({ value }: { value: string }) {
     setTimeout(() => setCopied(false), 1500);
   };
   return (
-    <code className="copyable-id" onClick={handleCopy} title="クリックでコピー">
-      {value}
-      <span className="copy-icon">{copied ? "\u2713" : "\u29C9"}</span>
-    </code>
+    <span className="copyable-id-wrap">
+      <code className="copyable-id-value">{value}</code>
+      <button className={`copyable-id-btn ${copied ? "copied" : ""}`} onClick={handleCopy} title="コピー">
+        {copied ? (
+          <svg viewBox="0 0 16 16" fill="none" width="14" height="14">
+            <path d="M3 8.5L6.5 12L13 4" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" />
+          </svg>
+        ) : (
+          <svg viewBox="0 0 16 16" fill="none" width="14" height="14">
+            <rect x="5.5" y="5.5" width="8" height="8" rx="1.5" stroke="currentColor" strokeWidth="1.5" />
+            <path d="M10.5 5.5V3.5C10.5 2.67 9.83 2 9 2H3.5C2.67 2 2 2.67 2 3.5V9C2 9.83 2.67 10.5 3.5 10.5H5.5" stroke="currentColor" strokeWidth="1.5" />
+          </svg>
+        )}
+      </button>
+    </span>
   );
 }
 

--- a/cli/src/web/style.css
+++ b/cli/src/web/style.css
@@ -1005,28 +1005,42 @@ main {
 }
 
 /* --- Copyable ID (click-to-copy inline badge) --- */
-.copyable-id {
+.copyable-id-wrap {
   display: inline-flex;
   align-items: center;
-  gap: 6px;
-  padding: 2px 8px;
-  background: var(--surface);
-  border-radius: 4px;
+  gap: 0;
+  border-radius: 6px;
+  overflow: hidden;
+  border: 1px solid var(--border);
+}
+.copyable-id-value {
+  padding: 4px 10px;
   font-size: 13px;
-  cursor: pointer;
-  user-select: none;
-  transition: background 0.15s;
+  color: var(--text-secondary);
+  user-select: all;
 }
-.copyable-id:hover {
-  background: var(--border);
-}
-.copyable-id .copy-icon {
+.copyable-id-btn {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  padding: 4px 8px;
+  border: none;
+  border-left: 1px solid var(--border);
+  background: var(--surface);
+  color: var(--text-secondary);
   font-size: 11px;
-  opacity: 0.5;
-  font-style: normal;
+  cursor: pointer;
+  transition: background 0.15s, color 0.15s;
 }
-.copyable-id:hover .copy-icon {
-  opacity: 1;
+.copyable-id-btn:hover {
+  background: var(--border);
+  color: var(--text);
+}
+.copyable-id-btn.copied {
+  color: var(--green);
+}
+.copyable-id-btn svg {
+  flex-shrink: 0;
 }
 
 .log-modal-body {

--- a/cli/src/web/style.css
+++ b/cli/src/web/style.css
@@ -1004,6 +1004,31 @@ main {
   text-decoration: underline;
 }
 
+/* --- Copyable ID (click-to-copy inline badge) --- */
+.copyable-id {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  padding: 2px 8px;
+  background: var(--surface);
+  border-radius: 4px;
+  font-size: 13px;
+  cursor: pointer;
+  user-select: none;
+  transition: background 0.15s;
+}
+.copyable-id:hover {
+  background: var(--border);
+}
+.copyable-id .copy-icon {
+  font-size: 11px;
+  opacity: 0.5;
+  font-style: normal;
+}
+.copyable-id:hover .copy-icon {
+  opacity: 1;
+}
+
 .log-modal-body {
   padding: 0 24px 24px;
   flex: 1;

--- a/cli/src/web/style.css
+++ b/cli/src/web/style.css
@@ -1022,23 +1022,21 @@ main {
 .copyable-id-btn {
   display: inline-flex;
   align-items: center;
+  align-self: stretch;
   gap: 4px;
-  padding: 4px 8px;
+  padding: 0 8px;
   border: none;
   border-left: 1px solid var(--border);
   background: var(--surface);
   color: var(--text-secondary);
   font-size: 11px;
   cursor: pointer;
+  outline: none;
   transition: background 0.15s, color 0.15s;
 }
 .copyable-id-btn:hover {
   background: var(--border);
   color: var(--text);
-}
-.copyable-id-btn:focus-visible {
-  outline: 2px solid var(--accent);
-  outline-offset: -2px;
 }
 .copyable-id-btn.copied {
   color: var(--green);

--- a/cli/src/web/style.css
+++ b/cli/src/web/style.css
@@ -1036,6 +1036,10 @@ main {
   background: var(--border);
   color: var(--text);
 }
+.copyable-id-btn:focus-visible {
+  outline: 2px solid var(--accent);
+  outline-offset: -2px;
+}
 .copyable-id-btn.copied {
   color: var(--green);
 }


### PR DESCRIPTION
## Summary
- タスク詳細画面にタスクIDを表示し、クリックでクリップボードにコピー可能に
- ログモーダルに実行レコードIDを表示し、クリックでクリップボードにコピー可能に
- `CopyableId` コンポーネントを共通パーツとして追加

## Test plan
- [ ] タスク詳細画面でタスクIDが表示されることを確認
- [ ] タスクIDをクリックしてクリップボードにコピーされることを確認
- [ ] ログモーダルで実行IDが表示されることを確認
- [ ] 実行IDをクリックしてクリップボードにコピーされることを確認
- [ ] コピー後にチェックマーク (✓) が 1.5秒間表示されることを確認

Closes #30

🤖 Generated with [Claude Code](https://claude.com/claude-code)